### PR TITLE
Fix "Download as ..." for wrong filenames

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -194,6 +194,16 @@ var documentsMain = {
 				iframe.find('#tb_toolbar-up_item_close').click(function() {
 					documentsMain.onClose();
 				});
+				var frameWindow = $('#loleafletframe')[0].contentWindow;
+				(function() {
+					cloudSuiteOnClick = frameWindow.onClick;
+					frameWindow.onClick = function() {
+						fileName = encodeURIComponent(title.substr(0, title.lastIndexOf('.')) || title);
+						frameWindow.map.options.doc = fileName;
+						cloudSuiteOnClick.apply(this, arguments);
+						frameWindow.map.options.doc = documentsMain.url;
+					};
+				})();
 			});
 		},
 


### PR DESCRIPTION
"Download as" links in File menu are downloading files with a different filename like `ccs-fileID.ext`. 
With this commit CloudSuite preserves original filenames when downloads them.