### PR TITLE
rpm package requirements update

### DIFF
--- a/owncloud-collabora-online.spec.in
+++ b/owncloud-collabora-online.spec.in
@@ -24,8 +24,7 @@ License:        MPL
 Source0:        owncloud-collabora-online-@PACKAGE_VERSION@.tar.gz
 BuildArch:      noarch
 Requires:       owncloud
-Requires:       loolwsd
-Requires:       loleaflet
+Requires:       php5-apcu
 
 %description
 


### PR DESCRIPTION
+ it does not require loleaflet and loolwsd, because
  loolwsd server can run on a separate machine, and
  loleaflet will be served by loolwsd in the near
  future.
+ it requires php5-apcu and the following line should be
  inserted to owncloud/config/config.php:
  'memcache.local' => '\OC\Memcache\APCu',