### PR TITLE
PHP syntax error on Ubuntu 14.04 LTS

### DIFF
--- a/lib/db/wopi.php
+++ b/lib/db/wopi.php
@@ -25,7 +25,7 @@ class Wopi extends \OCA\Richdocuments\Db{
 	const DB_TABLE = '`*PREFIX*richdocuments_wopi`';
 
 	// Tokens expire after this many seconds (not defined by WOPI specs).
-	const TOKEN_LIFETIME_SECONDS = 30 * 60;
+	const TOKEN_LIFETIME_SECONDS = 1800;
 
 	protected $tableName  = '`*PREFIX*richdocuments_wopi`';
 


### PR DESCRIPTION
syntax error, unexpected '*', expecting ',' or ';' at /var/www/owncloud/apps/richdocuments/lib/db/wopi.php#28