### PR TITLE
Make me work with owncloud9

### DIFF
--- a/appinfo/info.xml.in
+++ b/appinfo/info.xml.in
@@ -10,7 +10,7 @@
 	<repository type="git">https://github.com/owncloud/richdocuments.git</repository>
 	<category>productivity</category>
 	<dependencies>
-		<owncloud min-version="8.2" max-version="8.2" />
+		<owncloud min-version="8.2" max-version="9.0" />
 	</dependencies>
 	<public>
 		<richdocuments>public.php</richdocuments>

--- a/lib/storage.php
+++ b/lib/storage.php
@@ -139,11 +139,29 @@ class Storage {
 		Db\Session::cleanUp($session->getEsId());
 	}
 
+	private static function processDocuments($rawDocuments){
+		$documents = array();
+		foreach($rawDocuments as $rawDocument){
+			$document = array(
+				'fileid' => $rawDocument->getId(),
+				'path' => $rawDocument->getInternalPath(),
+				'name' => $rawDocument->getName(),
+				'mimetype' => $rawDocument->getMimetype()
+				);
+
+			array_push($documents, $document);
+		}
+
+		return $documents;
+	}
+
 	protected static function searchDocuments(){
 		$documents = array();
 		foreach (self::getSupportedMimetypes() as $mime){
-			$documents = array_merge($documents, \OCP\Files::searchByMime($mime));
+			$rawDocuments = \OCP\Files::searchByMime($mime);
+			$documents = array_merge($documents, self::processDocuments($rawDocuments));
 		}
+
 		return $documents;
 	}
 


### PR DESCRIPTION
Due to API change (searchByMime), app was completely broken when
installed with owncloud9. This change should make it work with
owncloud9, while still keeping older owncloud version (upto 8.2)
in working state.

Lets use functions on object returned by searchByMime instead of
directly accessing its data members.