### PR TITLE
bccu#1882: Return to where user started by removing redundant call

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -574,23 +574,6 @@ var documentsMain = {
 		documentsMain.UI.showEditor(documentsMain.fileName);
 	},
 
-	saveDocumentBack: function() {
-		var url = OC.generateUrl('apps/richdocuments/save/{file_id}', {file_id: documentsMain.fileId});
-		$.post(
-				url,
-				{ basename : documentsMain.baseName },
-				function(result) {
-					if (result && result.status === 'error') {
-						if (result.message){
-							documentsMain.IU.notify(result.message);
-						}
-						documentsMain.onEditorShutdown(t('richdocuments', 'Failed to save this document. Please check if it can be saved with an external editor. This might also mean it has been unshared or deleted recently.'));
-						return;
-					}
-				}
-			  );
-	},
-
 	renameDocument: function(name) {
 		var url = OC.generateUrl('apps/richdocuments/ajax/documents/rename/{file_id}', {file_id: documentsMain.fileId});
 		$.post(

--- a/js/documents.js
+++ b/js/documents.js
@@ -591,14 +591,6 @@ var documentsMain = {
 			  );
 	},
 
-	closeDocument: function() {
-		var url = OC.generateUrl('apps/richdocuments/close/{file_id}', {file_id: documentsMain.fileId});
-		$.post(
-				url,
-				{ basename : documentsMain.baseName }
-			  );
-	},
-
 	renameDocument: function(name) {
 		var url = OC.generateUrl('apps/richdocuments/ajax/documents/rename/{file_id}', {file_id: documentsMain.fileId});
 		$.post(
@@ -648,7 +640,6 @@ var documentsMain = {
 
 		$('footer,nav').show();
 		documentsMain.UI.hideEditor();
-		documentsMain.closeDocument();
 		$('#ocToolbar').remove();
 
 		if (documentsMain.returnToDir) {


### PR DESCRIPTION
Route /close/ doesn't mean anything, and we were making this
additional call always before closing the document. This had a
side-effect that sometimes /close/ call would be processed after
we assign returnToDir to window.location making browser always
stuck in richdocuments#index rather than reeturnToDir. This was
mainly the problem in firefox with owncloud9