### PR TITLE
Name file info.xml directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,5 @@ webodf/*
 build/*
 online
 loolvm
-appinfo/info.xml
 *.spec
 *.tar.gz

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -2,7 +2,7 @@
 <info>
 	<id>richdocuments</id>
 	<name>Collabora Online</name>
-	<description>Collabora Online allows you to to work with all kind office documents interactively direct in your browser.</description>
+	<description>Collabora Online allows you to to work with all kinds of office documents directly in your browser.</description>
 	<licence>AGPL</licence>
 	<version>1.1.0</version>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -2,9 +2,9 @@
 <info>
 	<id>richdocuments</id>
 	<name>Collabora Online</name>
-	<description>An ownCloud app to work with office documents</description>
+	<description>Collabora Online allows you to to work with all kind office documents interactively direct in your browser.</description>
 	<licence>AGPL</licence>
-	<version>@PACKAGE_VERSION@</version>
+	<version>1.1.0</version>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<bugs>https://github.com/owncloud/richdocuments/issues</bugs>
 	<repository type="git">https://github.com/owncloud/richdocuments.git</repository>


### PR DESCRIPTION
When developing apps for Nextcloud it is more usual that as a developer you can directly clone the app and enable it. The makefile is also very specific.

To improve the developer experience I have renamed that file to "info.xml" directly. At least I was kinda confused why I couldn't enable the app the first time I cloned it :-)