### PR TITLE
update name to fit in the app dropdown

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <info>
 	<id>richdocuments</id>
-	<name>Collabora Online</name>
+	<name>Office</name>
 	<description>Collabora Online allows you to to work with all kinds of office documents directly in your browser.</description>
 	<licence>AGPL</licence>
 	<version>1.1.2</version>


### PR DESCRIPTION
The long title »Collabora Online« doesn’t fit in the app dropdown and is longer than all the other app titles. Also, »Online« is a bit obvious here. ;)
![collabora title](https://cloud.githubusercontent.com/assets/925062/16954014/8c42ebf4-4dcf-11e6-84cc-76517ce068a8.png)

Please review @timar @pranavk @karlitschek @LukasReschke – the main question is if it’s fine from a branding point of view.