### PR TITLE
Fix name again, and version as well

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <info>
 	<id>richdocuments</id>
-	<name>Collabora Online</name>
+	<name>Office</name>
 	<description>Collabora Online allows you to to work with all kinds of office documents directly in your browser. This application requires Collabora Cloudsuite to be installed on one of your servers, please read the documentation to learn more about that.</description>
 	<summary>Edit office documents directly in your browser.</summary>
 	<licence>AGPL</licence>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -12,7 +12,7 @@
 	<category>office</category>
 	<category>integration</category>
 	<dependencies>
-		<owncloud min-version="8.2" max-version="9.0" />
+		<owncloud min-version="8.2" max-version="9.2" />
 	</dependencies>
 	<public>
 		<richdocuments>public.php</richdocuments>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -2,7 +2,7 @@
 script('richdocuments', 'admin');
 ?>
 <div class="section" id="richdocuments">
-	<h2><?php p($l->t('Collabora Online')) ?></h2>
+	<h2><?php p($l->t('Office')) ?></h2>
 	<label for="wopi_url"><?php p($l->t('Collabora Online server')) ?></label>
 	<input type="text" name="wopi_url" id="wopi_url" value="<?php p($_['wopi_url'])?>" style="width:300px;">
 	<br /><em><?php p($l->t('URL (and port) of the Collabora Online server that provides the editing functionality as a WOPI client.')) ?></em>

--- a/templates/personal.php
+++ b/templates/personal.php
@@ -2,7 +2,7 @@
 script('richdocuments', 'personal');
 ?>
 <div class="section" id="richdocuments-personal">
-	<h2><?php p($l->t('Collabora Online')); ?></h2>
+	<h2><?php p($l->t('Office')); ?></h2>
 	<div>
 		<label for="documents-default-path"><?php p($l->t('Save new documents to')) ?></label>
 		<input type="text" id="documents-default-path" value="<?php p($_['save_path']) ?>" /><span class="msg"></span>


### PR DESCRIPTION
For some reason the name change of https://github.com/owncloud/richdocuments/pull/90 in the info.xml wasn’t kept and I can’t see the change which did it. So I assume it’s an error.

Changed it again and also fixed the titles for the settings sections, fixing https://github.com/owncloud/richdocuments/issues/77

(And as well upped the max-version to 9.2 so it’s possible to install on a dev instance, e.g. Nextcloud 11.)

Please review @timar @LukasReschke @mar1u5