### PR TITLE
Respect default settings

### DIFF
--- a/appinfo/application.php
+++ b/appinfo/application.php
@@ -47,6 +47,7 @@ class Application extends App {
 				$c->query('AppName'),
 				$c->query('Request'),
 				$c->query('CoreConfig'),
+				$c->query('AppConfig'),
 				$c->query('L10N'),
 				$c->query('UserId'),
 				$c->query('ICacheFactory'),

--- a/controller/documentcontroller.php
+++ b/controller/documentcontroller.php
@@ -48,15 +48,17 @@ class DocumentController extends Controller {
 	private $uid;
 	private $l10n;
 	private $settings;
+	private $appConfig;
 	private $cache;
 	private $logger;
 	const ODT_TEMPLATE_PATH = '/assets/odttemplate.odt';
 
-	public function __construct($appName, IRequest $request, IConfig $settings, IL10N $l10n, $uid, ICacheFactory $cache, ILogger $logger){
+	public function __construct($appName, IRequest $request, IConfig $settings, IConfig $appConfig, IL10N $l10n, $uid, ICacheFactory $cache, ILogger $logger){
 		parent::__construct($appName, $request);
 		$this->uid = $uid;
 		$this->l10n = $l10n;
 		$this->settings = $settings;
+		$this->appConfig = $appConfig;
 		$this->cache = $cache->create($appName);
 		$this->logger = $logger;
 	}
@@ -121,7 +123,7 @@ class DocumentController extends Controller {
 	private function getDiscovery(){
 		\OC::$server->getLogger()->debug('getDiscovery(): Getting discovery.xml from the cache.');
 
-		$wopiRemote = $this->settings->getAppValue('richdocuments', 'wopi_url');
+		$wopiRemote = $this->appConfig->getAppValue('wopi_url');
 
 		// Provides access to information about the capabilities of a WOPI client
 		// and the mechanisms for invoking those abilities through URIs.
@@ -183,7 +185,7 @@ class DocumentController extends Controller {
 
 			if ($discovery_parsed === false) {
 				$this->cache->remove('discovery.xml');
-				$wopiRemote = $this->settings->getAppValue('richdocuments', 'wopi_url');
+				$wopiRemote = $this->appConfig->getAppValue('wopi_url');
 
 				return array(
 					'status' => 'error',
@@ -239,7 +241,7 @@ class DocumentController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	public function index(){
-		$wopiRemote = $this->settings->getAppValue('richdocuments', 'wopi_url');
+		$wopiRemote = $this->appConfig->getAppValue('wopi_url');
 		if (($parts = parse_url($wopiRemote)) && isset($parts['scheme']) && isset($parts['host'])) {
 			$webSocketProtocol = "ws://";
 			if ($parts['scheme'] == "https") {
@@ -336,7 +338,7 @@ class DocumentController extends Controller {
 
 			if ($discovery_parsed === false) {
 				$this->cache->remove('discovery.xml');
-				$wopiRemote = $this->settings->getAppValue('richdocuments', 'wopi_url');
+				$wopiRemote = $this->appConfig->getAppValue('wopi_url');
 
 				return array(
 					'status' => 'error',

--- a/tests/controller/documentcontrollertest.php
+++ b/tests/controller/documentcontrollertest.php
@@ -31,6 +31,10 @@ class DocumentControllerTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMock()
 		;
+		$this->appConfig = $this->getMockBuilder('\OCP\IConfig')
+			->disableOriginalConstructor()
+			->getMock()
+		;
 		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
 			->disableOriginalConstructor()
 			->getMock()
@@ -47,6 +51,7 @@ class DocumentControllerTest extends \PHPUnit_Framework_TestCase {
 			$this->appName,
 			$this->request,
 			$this->settings,
+			$this->appConfig,
 			$this->l10n,
 			$this->uid,
 			$this->cache,


### PR DESCRIPTION
Support for default settings when there is none provided by user
was already in lib/appconfig.php

But we were using the CoreConfig object always which queries the
database; lets use the appConfig object so that if the value is
missing in the database, we still have the default value to take
care of the app.