### PR TITLE
Show relative timestamps as heading, formatted as tooltip

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -217,7 +217,7 @@ var documentsMain = {
 
 		revHistoryItemTemplate: '<li>' +
 			'<a href="{{downloadUrl}}" class="downloadVersion has-tooltip" title="Download"><img src="{{downloadIconUrl}}" />' +
-			'<a class="versionPreview"><span class="versiondate has-tooltip" title="{{relativeTimestamp}}">{{formattedTimestamp}}</span></a>' +
+			'<a class="versionPreview"><span class="versiondate has-tooltip" title="{{formattedTimestamp}}">{{relativeTimestamp}}</span></a>' +
 			'<a href="{{restoreUrl}}" class="restoreVersion"><img src="{{restoreIconUrl}}" />' +
 			'</a>' +
 			'</li>',


### PR DESCRIPTION
Be consistent with owncloud own version sidebar, and loleaflet's
DocumentRepair dialog.