### PR TITLE
security: Support WOPI's PostMessageOrigin

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -328,6 +328,13 @@
 				<comments>Can make changes to this file</comments>
 			</field>
 			<field>
+				<name>server_host</name>
+				<type>text</type>
+				<default>localhost</default>
+				<notnull>true</notnull>
+				<comments>Host from which token generation request originated</comments>
+			</field>
+			<field>
 				<name>token</name>
 				<type>text</type>
 				<default></default>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>Collabora Online allows you to to work with all kinds of office documents directly in your browser. This application requires Collabora Cloudsuite to be installed on one of your servers, please read the documentation to learn more about that.</description>
 	<summary>Edit office documents directly in your browser.</summary>
 	<licence>AGPL</licence>
-	<version>1.1.10</version>
+	<version>1.1.11</version>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<bugs>https://github.com/owncloud/richdocuments/issues</bugs>
 	<repository type="git">https://github.com/owncloud/richdocuments.git</repository>

--- a/controller/documentcontroller.php
+++ b/controller/documentcontroller.php
@@ -503,7 +503,8 @@ class DocumentController extends Controller {
 		\OC::$server->getLogger()->debug('File with {fileid} has updatable set to {updatable}', [ 'app' => $this->appName, 'fileid' => $fileId, 'updatable' => $updatable ]);
 
 		$row = new Db\Wopi();
-		$token = $row->generateFileToken($fileId, $version, $updatable);
+		$serverHost = $this->request->getServerProtocol() . '://' . $this->request->getServerHost();
+		$token = $row->generateFileToken($fileId, $version, $updatable, $serverHost);
 
 		// Return the token.
 		return array(
@@ -543,7 +544,6 @@ class DocumentController extends Controller {
 		$this->loginUser($res['owner']);
 		$view = new \OC\Files\View('/' . $res['owner'] . '/files');
 		$info = $view->getFileInfo($res['path']);
-
 		$this->logoutUser();
 
 		if (!$info) {
@@ -558,7 +558,8 @@ class DocumentController extends Controller {
 			'Version' => $version,
 			'UserId' => $res['editor'],
 			'UserFriendlyName' => $editorName,
-			'UserCanWrite' => $res['canwrite'] ? 'true' : 'false'
+			'UserCanWrite' => $res['canwrite'] ? 'true' : 'false',
+			'PostMessageOrigin' => $res['server_host']
 		);
 	}
 

--- a/js/documents.js
+++ b/js/documents.js
@@ -478,8 +478,6 @@ var documentsMain = {
 						var editorInitListener = function(e) {
 							var msg = JSON.parse(e.data);
 							if (msg.MessageId === 'App_LoadingStatus') {
-								// LOOL Iframe is ready, turn off our overlay
-								documentsMain.overlay.documentOverlay('hide');
 								window.removeEventListener('message', editorInitListener, false);
 							}
 						};
@@ -493,16 +491,26 @@ var documentsMain = {
 								return;
 							}
 
-							var msg = JSON.parse(e.data);
-							if (msg.MessageId === 'UI_Close') {
+							try {
+								var msg = JSON.parse(e.data).MessageId;
+							} catch(exc) {
+								msg = e.data;
+							}
+							if (msg === 'UI_Close' || msg === 'close') {
 								documentsMain.onClose();
-							} else if (msg.MessageId === 'rev-history') {
+							} else if (msg === 'rev-history') {
 								documentsMain.UI.showRevHistory($('li[data-id=' + documentsMain.fileId + ']>a').attr('original-title'));
 							}
 						});
 
 						// Tell the LOOL iframe that we are ready now
 						documentsMain.WOPIPostMessage($('#loleafletframe')[0], 'Host_PostmessageReady', {});
+
+						// LOOL Iframe is ready, turn off our overlay
+						// This should ideally be taken off when we receive App_LoadingStatus, but
+						// for backward compatibility with older lool, lets keep it here till we decide
+						// to break older lools
+						documentsMain.overlay.documentOverlay('hide');
 					});
 
 					// submit that

--- a/lib/db/wopi.php
+++ b/lib/db/wopi.php
@@ -29,8 +29,8 @@ class Wopi extends \OCA\Richdocuments\Db{
 
 	protected $tableName  = '`*PREFIX*richdocuments_wopi`';
 
-	protected $insertStatement  = 'INSERT INTO `*PREFIX*richdocuments_wopi` (`owner_uid`, `editor_uid`, `fileid`, `version`, `path`, `canwrite`, `token`, `expiry`)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
+	protected $insertStatement  = 'INSERT INTO `*PREFIX*richdocuments_wopi` (`owner_uid`, `editor_uid`, `fileid`, `version`, `path`, `canwrite`, `server_host`, `token`, `expiry`)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)';
 
 	protected $loadStatement = 'SELECT * FROM `*PREFIX*richdocuments_wopi` WHERE `token`= ?';
 
@@ -41,7 +41,7 @@ class Wopi extends \OCA\Richdocuments\Db{
 	 * its the version number as stored by files_version app
 	 * Returns the token.
 	 */
-	public function generateFileToken($fileId, $version, $updatable){
+	public function generateFileToken($fileId, $version, $updatable, $serverHost){
 
 		// Get the FS view of the current user.
 		$view = \OC\Files\Filesystem::getView();
@@ -80,6 +80,7 @@ class Wopi extends \OCA\Richdocuments\Db{
 			$version,
 			$path,
 			$updatable,
+			$serverHost,
 			$token,
 			time() + self::TOKEN_LIFETIME_SECONDS
 		]);
@@ -125,7 +126,8 @@ class Wopi extends \OCA\Richdocuments\Db{
 			'owner' => $row['owner_uid'],
 			'editor' => $row['editor_uid'],
 			'path' => $row['path'],
-			'canwrite' => $row['canwrite']
+			'canwrite' => $row['canwrite'],
+			'server_host' => $row['server_host']
 		);
 	}
 }


### PR DESCRIPTION
Adds a new property PostMessageOrigin to WOPI's CheckFileInfo.
The inner frame then only sends message to target with origin
mentioned in this property.

Also implement editor initialization WOPI specs. Inner frame
sends a App_LoadingStatus message to us when ready, and we send
Host_PostmessageReady when we are ready.