### PR TITLE
Missing response property

### DIFF
--- a/controller/documentcontroller.php
+++ b/controller/documentcontroller.php
@@ -557,6 +557,7 @@ class DocumentController extends Controller {
 			'BaseFileName' => $info['name'],
 			'Size' => $info['size'],
 			'Version' => $version,
+			'OwnerId' => $res['owner'],
 			'UserId' => $res['editor'],
 			'UserFriendlyName' => $editorName,
 			'UserCanWrite' => $res['canwrite'] ? true : false,


### PR DESCRIPTION
'OwnerId' is a required property (http://wopi.readthedocs.io/projects/wopirest/en/latest/files/CheckFileInfo.html#required-response-properties).

Microsoft Office Online won't work without this property. :)