### PR TITLE
Include support for X-LOOL-WOPI-Timestamp

### DIFF
--- a/lib/helper.php
+++ b/lib/helper.php
@@ -12,6 +12,9 @@
 
 namespace OCA\Richdocuments;
 
+use \DateTime;
+use \DateTimeZone;
+
 class Helper {
 
 	const APP_ID = 'richdocuments';
@@ -40,6 +43,20 @@ class Helper {
 			$instanceId,
 			$version,
 		];
+	}
+
+	/**
+	 * WOPI helper function to convert to ISO 8601 round-trip format.
+	 * @param integer $time Must be seconds since unix epoch
+	 */
+	public static function toISO8601($time)
+	{
+		// TODO: Be more precise and don't ignore milli, micro seconds ?
+		$datetime = DateTime::createFromFormat('U', $time, new DateTimeZone('UTC'));
+		if ($datetime)
+			return $datetime->format('Y-m-d\TH:i:s.u\Z');
+
+		return false;
 	}
 
 	public static function getNewFileName($view, $path, $prepend = ' '){


### PR DESCRIPTION
This is a WOPI extension to detect any external document change. For
example, when the file that is already opened by LOOL is changed (for
example, using upload mechanism or any other way).

The WOPI host (OwnCloud) sends LastModifiedTime (in WOPI specs) as part
of the CheckFileInfo response. It also expects WOPI client to send the
same timestamp in X-LOOL-WOPI-Timestamp header during WOPI::PutFile. If
this header is present, then WOPI host checks, before saving the
document, if the timestamp in the header is equal to the timestamp of
the file in its storage. Only upon meeting this condition, it saves the
file back to storage, otherwise it informs WOPI client about some change
to the document.

WOPI client is supposed to inform the user accordingly. If user is okay
with over-writing the document, then WOPI client can omit sending
X-LOOL-WOPI-Timestamp header, in which case, no check as mentioned above
would be performed while saving the file and document will be
overwritten.