### PR TITLE
Add support for PutRelativeFile for Save As.

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -39,6 +39,7 @@ $application->registerRoutes($this, [
 		['name' => 'document#wopiCheckFileInfo', 'url' => 'wopi/files/{fileId}', 'verb' => 'GET'],
 		['name' => 'document#wopiGetFile', 'url' => 'wopi/files/{fileId}/contents', 'verb' => 'GET'],
 		['name' => 'document#wopiPutFile', 'url' => 'wopi/files/{fileId}/contents', 'verb' => 'POST'],
+		['name' => 'document#wopiPutRelativeFile', 'url' => 'wopi/files/{fileId}', 'verb' => 'POST'],
 		//settings
 		['name' => 'settings#setSettings', 'url' => 'ajax/admin.php', 'verb' => 'POST'],
 		['name' => 'settings#getSupportedMimes', 'url' => 'ajax/mimes.php', 'verb' => 'GET'],

--- a/js/documents.js
+++ b/js/documents.js
@@ -504,6 +504,26 @@ var documentsMain = {
 								documentsMain.onClose();
 							} else if (msg === 'rev-history') {
 								documentsMain.UI.showRevHistory($('li[data-id=' + documentsMain.fileId + ']>a').attr('original-title'));
+							} else if (msg === 'UI_SaveAs') {
+								// TODO it's not possible to enter the
+								// filename into the OC.dialogs.filepicker; so
+								// it will be necessary to use an own tree
+								// view or something :-(
+								//OC.dialogs.filepicker(t('richdocuments', 'Save As'),
+								//	function(val) {
+								//		console.log(val);
+								//		documentsMain.WOPIPostMessage($('#loleafletframe')[0], 'Action_SaveAs', {'Filename': val});
+								//	}, false, null, true);
+								OC.dialogs.prompt(t('richdocuments', 'Please enter filename to which this document should be stored.'),
+										t('richdocuments', 'Save As'),
+										function(result, value) {
+											if (result === true) {
+												documentsMain.WOPIPostMessage($('#loleafletframe')[0], 'Action_SaveAs', {'Filename': value});
+											}
+										},
+										true,
+										t('richdocuments', 'New filename'),
+										false);
 							}
 						});
 

--- a/lib/db/wopi.php
+++ b/lib/db/wopi.php
@@ -41,7 +41,7 @@ class Wopi extends \OCA\Richdocuments\Db{
 	 * its the version number as stored by files_version app
 	 * Returns the token.
 	 */
-	public function generateFileToken($fileId, $version, $updatable, $serverHost){
+	public function generateFileToken($fileId, $version, $updatable, $serverHost, $editor){
 
 		// Get the FS view of the current user.
 		$view = \OC\Files\Filesystem::getView();
@@ -63,8 +63,6 @@ class Wopi extends \OCA\Richdocuments\Db{
 		if (!$view->is_file($path)) {
 			throw new \Exception('Invalid fileId.');
 		}
-
-		$editor = \OC::$server->getUserSession()->getUser()->getUID();
 
 		$token = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate(32,
 					\OCP\Security\ISecureRandom::CHAR_LOWER . \OCP\Security\ISecureRandom::CHAR_UPPER .


### PR DESCRIPTION
This needs Collabora Online 2.1.5 to show anything in the UI, but should be safe with 2.1.4 and older, and not affect those versions in any way.