### PR TITLE
Add support for adding canonical webroot

### DIFF
--- a/controller/documentcontroller.php
+++ b/controller/documentcontroller.php
@@ -328,7 +328,8 @@ class DocumentController extends Controller {
 			'allowShareWithLink' => $this->settings->getAppValue('core', 'shareapi_allow_links', 'yes'),
 			'wopi_url' => $webSocket,
 			'doc_format' => $this->appConfig->getAppValue('doc_format'),
-			'instanceId' => $this->settings->getSystemValue('instanceid')
+			'instanceId' => $this->settings->getSystemValue('instanceid'),
+			'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot')
 		);
 
 		if (!is_null($fileId)) {

--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -76,13 +76,14 @@ class SettingsController extends Controller{
 				'doc_format' => $this->appConfig->getAppValue('doc_format'),
 				'test_wopi_url' => $this->appConfig->getAppValue('test_wopi_url'),
 				'test_server_groups' => $this->appConfig->getAppValue('test_server_groups'),
-				'external_apps' => $this->appConfig->getAppValue('external_apps')
+				'external_apps' => $this->appConfig->getAppValue('external_apps'),
+				'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot')
 			],
 			'blank'
 		);
 	}
 
-	public function setSettings($wopi_url, $edit_groups, $doc_format, $test_wopi_url, $test_server_groups, $external_apps){
+	public function setSettings($wopi_url, $edit_groups, $doc_format, $test_wopi_url, $test_server_groups, $external_apps, $canonical_webroot){
 		$message = $this->l10n->t('Saved');
 
 		if (!is_null($wopi_url)){
@@ -112,6 +113,10 @@ class SettingsController extends Controller{
 
 		if (!is_null($external_apps)){
 			$this->appConfig->setAppValue('external_apps', $external_apps);
+		}
+
+		if (!is_null($canonical_webroot)){
+			$this->appConfig->setAppValue('canonical_webroot', $canonical_webroot);
 		}
 
 		$richMemCache = \OC::$server->getMemCacheFactory()->create('richdocuments');

--- a/js/admin.js
+++ b/js/admin.js
@@ -276,7 +276,7 @@ var documentsSettings = {
 			if (!this.checked) {
 				documentsSettings.saveWebroot('');
 			} else {
-				var val = $('#canonical-webroot').value();
+				var val = $('#canonical-webroot').val();
 				if (val)
 					documentsSettings.saveWebroot();
 			}

--- a/js/admin.js
+++ b/js/admin.js
@@ -85,6 +85,18 @@ var documentsSettings = {
 		);
 	},
 
+	saveWebroot: function(value) {
+		var data = {
+			'canonical_webroot': value
+		};
+
+		console.log('saving new webroot: ' + value);
+		$.post(
+			OC.filePath('richdocuments', 'ajax', 'admin.php'),
+			data
+		);
+	},
+
 	afterSaveExternalApps: function(response) {
 		OC.msg.finishedAction('#enable-external-apps-section-msg', response);
 	},
@@ -255,6 +267,23 @@ var documentsSettings = {
 			}
 
 			$select.change();
+		});
+
+		$(document).on('change', '#enable_canonical_webroot_cb-richdocuments', function() {
+			var page = $(this).parent();
+
+			page.find('#enable-canonical-webroot-section').toggleClass('hidden', !this.checked);
+			if (!this.checked) {
+				documentsSettings.saveWebroot('');
+			} else {
+				var val = $('#canonical-webroot').value();
+				if (val)
+					documentsSettings.saveWebroot();
+			}
+		});
+
+		$(document).on('change', '#canonical-webroot', function() {
+			documentsSettings.saveWebroot(this.value);
 		});
 	}
 };

--- a/js/documents.js
+++ b/js/documents.js
@@ -177,6 +177,19 @@ var documentsMain = {
 	toolbar : '<div id="ocToolbar"><div id="ocToolbarInside"></div><span id="toolbar" class="claro"></span></div>',
 	returnToDir : null, // directory where we started from in the 'Files' app
 
+	// generates docKey for given fileId
+	_generateDocKey: function(wopiFileId) {
+		var ocurl = OC.generateUrl('apps/richdocuments/wopi/files/{file_id}', {file_id: wopiFileId});
+		if (rd_canonical_webroot) {
+			if (!rd_canonical_webroot.startsWith('/'))
+				rd_canonical_webroot = '/' + rd_canonical_webroot;
+
+			ocurl = ocurl.replace(OC.webroot, rd_canonical_webroot);
+		}
+
+		return ocurl;
+	},
+
 	UI : {
 		/* Editor wrapper HTML */
 		container : '<div id="mainContainer" class="claro">' +
@@ -222,8 +235,9 @@ var documentsMain = {
 				$('#revViewerContainer').prepend($('<div id="revViewer">'));
 			}
 
+			var ocurl = documentsMain._generateDocKey(fileId);
 			// WOPISrc - URL that loolwsd will access (ie. pointing to ownCloud)
-			var wopiurl = window.location.protocol + '//' + window.location.host + OC.generateUrl('apps/richdocuments/wopi/files/{file_id}', {file_id: fileId});
+			var wopiurl = window.location.protocol + '//' + window.location.host + ocurl;
 			var wopisrc = encodeURIComponent(wopiurl);
 
 			// urlsrc - the URL from discovery xml that we access for the particular
@@ -409,9 +423,10 @@ var documentsMain = {
 			$('title').text(title + ' - ' + documentsMain.UI.mainTitle);
 
 			var wopiFileId = documentsMain.fileId;
+			var ocurl = documentsMain._generateDocKey(wopiFileId);
 			// WOPISrc - URL that loolwsd will access (ie. pointing to ownCloud)
 			// Include the unique instanceId in the WOPI URL as part of the fileId
-			var wopiurl = window.location.protocol + '//' + window.location.host + OC.generateUrl('apps/richdocuments/wopi/files/{file_id}', {file_id: wopiFileId});
+			var wopiurl = window.location.protocol + '//' + window.location.host + ocurl;
 			var wopisrc = encodeURIComponent(wopiurl);
 
 			// urlsrc - the URL from discovery xml that we access for the particular

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -41,4 +41,13 @@ script('richdocuments', 'admin');
 	    <button type="button" id="external-apps-add-button"><?php p($l->t('Add')) ?></button>
 	    <span id="enable-external-apps-section-msg" class="msg"></span>
 	</div>
+
+	<br/>
+	<input type="checkbox" id="enable_canonical_webroot_cb-richdocuments" <?php p($_['canonical_webroot'] !== '' ? 'checked' : '') ?> />
+	<label for="canonical_webroot_cb-richdocuments"><?php p($l->t('Use Canonical webroot')) ?></label>
+	<div id="enable-canonical-webroot-section" class="indent <?php if ($_['canonical_webroot'] == '') p('hidden') ?>" >
+	<input type="text" id="canonical-webroot" name="canonical-webroot-name" value="<?php p($_['canonical_webroot']) ?>">
+	<br/>
+	<em><?php p($l->t('Canonical owncloud webroot that Collabora should use.')) ?></em>
+	</div>
 </div>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -48,6 +48,6 @@ script('richdocuments', 'admin');
 	<div id="enable-canonical-webroot-section" class="indent <?php if ($_['canonical_webroot'] == '') p('hidden') ?>" >
 	<input type="text" id="canonical-webroot" name="canonical-webroot-name" value="<?php p($_['canonical_webroot']) ?>">
 	<br/>
-	<em><?php p($l->t('Canonical owncloud webroot that Collabora should use.')) ?></em>
+	<em><?php p($l->t('Canonical webroot, in case there are multiple, for Collabora to use. Provide the one with least restrictions. Eg: Use non-shibbolized webroot if this instance is accessed by both shibbolized and non-shibbolized webroots. You can ignore this setting if only one webroot is used to access this instance.')) ?></em>
 	</div>
 </div>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -48,6 +48,6 @@ script('richdocuments', 'admin');
 	<div id="enable-canonical-webroot-section" class="indent <?php if ($_['canonical_webroot'] == '') p('hidden') ?>" >
 	<input type="text" id="canonical-webroot" name="canonical-webroot-name" value="<?php p($_['canonical_webroot']) ?>">
 	<br/>
-	<em><?php p($l->t('Canonical webroot, in case there are multiple, for Collabora to use. Provide the one with least restrictions. Eg: Use non-shibbolized webroot if this instance is accessed by both shibbolized and non-shibbolized webroots. You can ignore this setting if only one webroot is used to access this instance.')) ?></em>
+	<p style="max-width: 50em;"><em><?php p($l->t('Canonical webroot, in case there are multiple, for Collabora to use. Provide the one with least restrictions. Eg: Use non-shibbolized webroot if this instance is accessed by both shibbolized and non-shibbolized webroots. You can ignore this setting if only one webroot is used to access this instance.')) ?></em></p>
 	</div>
 </div>

--- a/templates/documents.php
+++ b/templates/documents.php
@@ -6,6 +6,7 @@
 	 var rd_token = '<?php p($_['token']) ?>';
 	 var rd_urlsrc = '<?php p($_['urlsrc']) ?>';
 	 var rd_path = '<?php p($_['path']) ?>';
+	 var rd_canonical_webroot = '<?php p($_['canonical_webroot']) ?>';
 </script>
 
 <?php


### PR DESCRIPTION
This is useful when the same owncloud instance is accessed by multiple
URLs. It is important that we feed same URL to Collabora Online for the
same document otherwise collaborative editing wouldn't be possible.

This is especially useful in case of authentication mechanisms like
Shibboleth where some URLs are protected. Collabora
Online cannot access such URLs; by providing canonical webroot we feed
only the accessible URL to Collabora Online.

Eg: Same owncloud instance accessed by /owncloud and /owncloud-shib
(only latter protected by shibboleth).

In this case, one should put /owncloud as the Canonical webroot in
Collabora Online settings.