### PR TITLE
Adjust composer files and app core min-version for 'drop PHP 5.6'

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -15,7 +15,7 @@
 		<prevent_group_restriction/>
 	</types>
 	<dependencies>
-		<owncloud min-version="9.1.7" max-version="10" />
+		<owncloud min-version="10.2" max-version="10" />
 	</dependencies>
 	<screenshot>https://owncloud.com/wp-content/uploads/2016/07/code_v2_writer-1-1024x576.png</screenshot>
 	<screenshot>https://owncloud.com/wp-content/uploads/2016/07/code_v2_calc-1-1024x576.png</screenshot>

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "owncloud/richdocuments",
   "config": {
     "platform": {
-      "php": "5.6.37"
+      "php": "7.0.8"
     }
   },
   "require": {},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "76fea35b97470e80cfeda1af6cb0255a",
+    "content-hash": "11b5470fe902cc152811678f4b50ce8d",
     "packages": [],
     "packages-dev": [
         {
@@ -55,6 +55,6 @@
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
-        "php": "5.6.37"
+        "php": "7.0.8"
     }
 }


### PR DESCRIPTION
- [x] adjust local `composer` files to PHP 7.0.8
- [x] bump app core min-version to `10.2`

because the app is now being tested only against core `stable10` upcoming `10.2` that has dropped PHP 5.6 support.
