### PR TITLE
Dont enable incognito mode if no encryption enabled

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -91,4 +91,21 @@ class AppConfig {
 
 		return true;
 	}
+
+	/**
+	 * Check if encryption is enabled
+	 *
+	 * @return bool
+	 */
+	public function encryptionEnabled() {
+		if (!$this->appManager->isEnabledForUser('encryption') && !\getenv('CI')) {
+			return false;
+		}
+
+		if (!\OC::$server->getEncryptionManager()->isEnabled()) {
+			return false;
+		}
+
+		return true;
+	}
 }

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -849,7 +849,7 @@ class DocumentController extends Controller {
 			'UserId' => $res['editor'],
 			'UserFriendlyName' => $editor->getDisplayName(),
 			'UserCanWrite' => $canWrite,
-			'UserCanNotWriteRelative' => \OC::$server->getEncryptionManager()->isEnabled() ? true : false,
+			'UserCanNotWriteRelative' => $this->appConfig->encryptionEnabled(),
 			'PostMessageOrigin' => $res['server_host'],
 			'LastModifiedTime' => Helper::toISO8601($info->getMTime())
 		];
@@ -935,8 +935,12 @@ class DocumentController extends Controller {
 
 		$this->logoutUser();
 
-		// This is required to be able to read encrypted documents
-		\OC_User::setIncognitoMode(true);
+		if ($this->appConfig->encryptionEnabled()) {
+			// with encryption, change needs to be applied as unknown user
+			// this also means that changes wont be auditable
+			\OC_User::setIncognitoMode(true);
+		}
+
 		// This is required for reading encrypted files
 		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($ownerid);
@@ -1049,8 +1053,12 @@ class DocumentController extends Controller {
 			'editor' => $res['editor'],
 			'owner' => $res['owner']]);
 
-		// To be able to make it work when server-side encryption is enabled
-		\OC_User::setIncognitoMode(true);
+		if ($this->appConfig->encryptionEnabled()) {
+			// with encryption, change needs to be applied as unknown user
+			// this also means that changes wont be auditable
+			\OC_User::setIncognitoMode(true);
+		}
+
 		// Setup the FS which is needed to emit hooks (versioning).
 		\OC_Util::tearDownFS();
 		if ($isPutRelative) {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -66,6 +66,7 @@ class SettingsController extends Controller {
 				'external_apps' => $this->appConfig->getAppValue('external_apps'),
 				'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
 				'menu_option' => $this->appConfig->getAppValue('menu_option'),
+				'encryption_enabled' => $this->appConfig->encryptionEnabled() ? 'true' : 'false',
 				'secure_view_allowed' => $this->appConfig->enterpriseFeaturesEnabled() ? 'true' : 'false',
 				'secure_view_option' => $this->appConfig->getAppValue('secure_view_option'),
 				'secure_view_has_watermark_default' => $this->appConfig->getAppValue('secure_view_has_watermark_default'),

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -7,7 +7,10 @@ script('richdocuments', 'admin');
                 title="<?php p($l->t('Open documentation'));?>"
                 href="https://github.com/owncloud/richdocuments/wiki"></a>
 
-        <br/>
+    <br/>
+	<p style="max-width: 50em; color: red;"><?php if ($_['encryption_enabled'] === 'true') {
+	p($l->t("Encryption with master or user key is enabled, the changes made to the files by users will only be auditable within this app"));
+} ?></p>
 	<label for="wopi_url"><?php p($l->t('Collabora Online server')) ?></label>
 	<input type="text" name="wopi_url" id="wopi_url" value="<?php p($_['wopi_url'])?>" style="width:300px;">
 	<br/><em><?php p($l->t('URL (and port) of the Collabora Online server that provides the editing functionality as a WOPI client.')) ?></em>


### PR DESCRIPTION
Currently with encryption enabled, app requires incognito mode to be enabled. Without the encryption, the incognito causes that activity for this app is not auditable.

Future work: make collabora work with audit for master key encryption (for user key we cannot do anything unfortunetely)