### PR TITLE
Make master encryption compatible with audit/activity

### DIFF
--- a/appinfo/Migrations/Version20190623184232.php
+++ b/appinfo/Migrations/Version20190623184232.php
@@ -1,0 +1,20 @@
+<?php
+namespace OCA\richdocuments\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version20190623184232 implements ISchemaMigration {
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+
+		$table = $schema->getTable("{$prefix}richdocuments_wopi");
+
+		if ($table->hasColumn('path')) {
+			$table->dropColumn('path');
+		}
+	}
+}

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>Collabora Online allows you to to work with all kinds of office documents directly in your browser. This application can connect to a Collabora Online server (WOPI Client). ownCloud is the WOPI Host. Please read the documentation to learn more about that.</description>
 	<summary>Edit office documents directly in your browser.</summary>
 	<licence>AGPL</licence>
-	<version>2.1.2</version>
+	<version>2.2.0</version>
 	<author>Collabora Productivity based on work of Frank Karlitschek, Victor Dubiniuk</author>
 	<bugs>https://github.com/owncloud/richdocuments/issues</bugs>
 	<repository type="git">https://github.com/owncloud/richdocuments.git</repository>

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -91,4 +91,21 @@ class AppConfig {
 
 		return true;
 	}
+
+	/**
+	 * Check if encryption is enabled
+	 *
+	 * @return bool
+	 */
+	public function encryptionEnabled() {
+		if (!$this->appManager->isEnabledForUser('encryption') && !\getenv('CI')) {
+			return false;
+		}
+
+		if (!\OC::$server->getEncryptionManager()->isEnabled()) {
+			return false;
+		}
+
+		return true;
+	}
 }

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -13,6 +13,7 @@ namespace OCA\Richdocuments;
 
 use OCP\App\IAppManager;
 use \OCP\IConfig;
+use \OCA\Encryption\Util;
 
 class AppConfig {
 	private $appName = 'richdocuments';
@@ -103,6 +104,23 @@ class AppConfig {
 		}
 
 		if (!\OC::$server->getEncryptionManager()->isEnabled()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if encryption is enabled
+	 *
+	 * @return bool
+	 */
+	public function userEncryptionEnabled() {
+		if (!$this->encryptionEnabled()) {
+			return false;
+		}
+
+		if (!\OC::$server->query(Util::class)->isMasterKeyEnabled()) {
 			return false;
 		}
 

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -111,16 +111,25 @@ class AppConfig {
 	}
 
 	/**
-	 * Check if encryption is enabled
+	 * Check if master encryption is enabled
 	 *
 	 * @return bool
 	 */
-	public function userEncryptionEnabled() {
+	public function masterEncryptionEnabled() {
 		if (!$this->encryptionEnabled()) {
 			return false;
 		}
 
-		if (!\OC::$server->query(Util::class)->isMasterKeyEnabled()) {
+		return \OC::$server->query(Util::class)->isMasterKeyEnabled();
+	}
+
+	/**
+	 * Check if user encryption is enabled
+	 *
+	 * @return bool
+	 */
+	public function userEncryptionEnabled() {
+		if (!$this->masterEncryptionEnabled()) {
 			return false;
 		}
 

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -685,13 +685,6 @@ class DocumentController extends Controller {
 
 		$this->updateDocumentEncryptionAccessList($ownerUid, $currentUser, $path);
 
-		if (!$currentUser) {
-			// if no user is authenticated and public link, use owner as granding access to file
-			$editorUid = '';
-		} else {
-			$editorUid = $currentUser;
-		}
-
 		$updateable = ($permissions & Constants::PERMISSION_UPDATE) === Constants::PERMISSION_UPDATE;
 		// If token is for some versioned file
 		if ($version !== '0') {
@@ -706,7 +699,7 @@ class DocumentController extends Controller {
 		}
 
 		$row = new Db\Wopi();
-		$token = $row->generateToken($fileId, $version, $attributes, $serverHost, $ownerUid, $editorUid);
+		$token = $row->generateToken($fileId, $version, $attributes, $serverHost, $ownerUid, $currentUser);
 
 		// Return the token.
 		$result = [
@@ -789,7 +782,7 @@ class DocumentController extends Controller {
 			$editorDisplayName = $editor->getDisplayName();
 			$editorEmail = $editor->getEMailAddress();
 		} else {
-			$editorId = $this->l10n->t('remote user');;
+			$editorId = $this->l10n->t('remote user');
 			$editorDisplayName = $this->l10n->t('remote user');
 			$editorEmail = null;
 		}

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -1018,6 +1018,11 @@ class DocumentController extends Controller {
 	}
 
 	private function putRelative($fileId, $token) {
+		if ($this->appConfig->encryptionEnabled()) {
+			$this->logger->debug('wopiPutFile(): Encryption unsupported with PutRelative.', ['app' => $this->appName]);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		}
+
 		$row = new Db\Wopi();
 		$row->loadBy('token', $token);
 

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -849,7 +849,7 @@ class DocumentController extends Controller {
 			'UserId' => $res['editor'],
 			'UserFriendlyName' => $editor->getDisplayName(),
 			'UserCanWrite' => $canWrite,
-			'UserCanNotWriteRelative' => \OC::$server->getEncryptionManager()->isEnabled() ? true : false,
+			'UserCanNotWriteRelative' => $this->appConfig->encryptionEnabled(),
 			'PostMessageOrigin' => $res['server_host'],
 			'LastModifiedTime' => Helper::toISO8601($info->getMTime())
 		];
@@ -935,8 +935,12 @@ class DocumentController extends Controller {
 
 		$this->logoutUser();
 
-		// This is required to be able to read encrypted documents
-		\OC_User::setIncognitoMode(true);
+		if ($this->appConfig->encryptionEnabled()) {
+			// with encryption, change needs to be applied as unknown user
+			// this also means that changes wont be auditable
+			\OC_User::setIncognitoMode(true);
+		}
+
 		// This is required for reading encrypted files
 		\OC_Util::tearDownFS();
 		\OC_Util::setupFS($ownerid);
@@ -1049,8 +1053,12 @@ class DocumentController extends Controller {
 			'editor' => $res['editor'],
 			'owner' => $res['owner']]);
 
-		// To be able to make it work when server-side encryption is enabled
-		\OC_User::setIncognitoMode(true);
+		if ($this->appConfig->encryptionEnabled()) {
+			// with encryption, change needs to be applied as unknown user
+			// this also means that changes wont be auditable
+			\OC_User::setIncognitoMode(true);
+		}
+
 		// Setup the FS which is needed to emit hooks (versioning).
 		\OC_Util::tearDownFS();
 		if ($isPutRelative) {

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -940,6 +940,14 @@ class DocumentController extends Controller {
 			'token' => $token,
 			'wopiOverride' => $this->request->getHeader('X-WOPI-Override')]);
 
+		if ($isPutRelative) {
+			return $this->putRelative($fileId, $token);
+		} else {
+			return $this->put($fileId, $token);
+		}
+	}
+
+	private function put($fileId, $token) {
 		$row = new Db\Wopi();
 		$row->loadBy('token', $token);
 
@@ -965,56 +973,19 @@ class DocumentController extends Controller {
 		$userFolder = \OC::$server->getRootFolder()->getUserFolder($res['owner']);
 		$file = $userFolder->getById($fileId)[0];
 
-		if ($isPutRelative) {
-			// the new file needs to be installed in the current user dir
-			$userFolder = \OC::$server->getRootFolder()->getUserFolder($res['editor']);
-			$file = $userFolder->getById($fileId)[0];
-
-			$suggested = $this->request->getHeader('X-WOPI-SuggestedTarget');
-			$suggested = \iconv('utf-7', 'utf-8', $suggested);
-
-			$path = '';
-			if ($suggested[0] === '.') {
-				$path = \dirname($file->getPath()) . '/New File' . $suggested;
-			} elseif ($suggested[0] !== '/') {
-				$path = \dirname($file->getPath()) . '/' . $suggested;
-			} else {
-				$path = $userFolder->getPath() . $suggested;
-			}
-
-			if ($path === '') {
-				return [
-					'status' => 'error',
-					'message' => 'Cannot create the file'
-				];
-			}
-
-			$root = \OC::$server->getRootFolder();
-
-			// create the folder first
-			if (!$root->nodeExists(\dirname($path))) {
-				$root->newFolder(\dirname($path));
-			}
-
-			// create a unique new file
-			$path = $root->getNonExistingName($path);
-			$root->newFile($path);
-			$file = $root->get($path);
-		} else {
-			$wopiHeaderTime = $this->request->getHeader('X-LOOL-WOPI-Timestamp');
-			$this->logger->debug('wopiPutFile(): WOPI header timestamp: {wopiHeaderTime}', [
+		$wopiHeaderTime = $this->request->getHeader('X-LOOL-WOPI-Timestamp');
+		$this->logger->debug('wopiPutFile(): WOPI header timestamp: {wopiHeaderTime}', [
+			'app' => $this->appName,
+			'wopiHeaderTime' => $wopiHeaderTime]);
+		if (!$wopiHeaderTime) {
+			$this->logger->debug('wopiPutFile(): X-LOOL-WOPI-Timestamp absent. Saving file.', ['app' => $this->appName]);
+		} elseif ($wopiHeaderTime != Helper::toISO8601($file->getMTime())) {
+			$this->logger->debug('wopiPutFile(): Document timestamp mismatch ! WOPI client says mtime {headerTime} but storage says {storageTime}', [
 				'app' => $this->appName,
-				'wopiHeaderTime' => $wopiHeaderTime]);
-			if (!$wopiHeaderTime) {
-				$this->logger->debug('wopiPutFile(): X-LOOL-WOPI-Timestamp absent. Saving file.', ['app' => $this->appName]);
-			} elseif ($wopiHeaderTime != Helper::toISO8601($file->getMTime())) {
-				$this->logger->debug('wopiPutFile(): Document timestamp mismatch ! WOPI client says mtime {headerTime} but storage says {storageTime}', [
-					'app' => $this->appName,
-					'headerTime' => $wopiHeaderTime,
-					'storageTime' => Helper::toISO8601($file->getMtime())]);
-				// Tell WOPI client about this conflict.
-				return new JSONResponse(['LOOLStatusCode' => self::LOOL_STATUS_DOC_CHANGED], Http::STATUS_CONFLICT);
-			}
+				'headerTime' => $wopiHeaderTime,
+				'storageTime' => Helper::toISO8601($file->getMtime())]);
+			// Tell WOPI client about this conflict.
+			return new JSONResponse(['LOOLStatusCode' => self::LOOL_STATUS_DOC_CHANGED], Http::STATUS_CONFLICT);
 		}
 
 		// Read the contents of the file from the POST body and store.
@@ -1033,35 +1004,112 @@ class DocumentController extends Controller {
 
 		// Setup the FS which is needed to emit hooks (versioning).
 		\OC_Util::tearDownFS();
-		if ($isPutRelative) {
-			\OC_Util::setupFS($res['editor']);
-		} else {
-			\OC_Util::setupFS($res['owner']);
-		}
+
+		\OC_Util::setupFS($res['owner']);
+
 		$file->putContent($content);
 		$mtime = $file->getMtime();
 
-		if ($isPutRelative) {
-			// generate a token for the new file (the user still has to be
-			// logged in)
-			$row = new Wopi();
-			$serverHost = $this->request->getServerProtocol() . '://' . $this->request->getServerHost();
+		$this->logoutUser();
+		return [
+			'status' => 'success',
+			'LastModifiedTime' => Helper::toISO8601($mtime)
+		];
+	}
 
-			$attributes = WOPI::ATTR_CAN_VIEW | WOPI::ATTR_CAN_UPDATE | WOPI::ATTR_CAN_DOWNLOAD | WOPI::ATTR_CAN_PRINT;
-			$wopiToken = $row->generateToken($file->getId(), $res['path'], 0, $attributes, $serverHost, $res['owner'], $res['editor']);
+	private function putRelative($fileId, $token) {
+		$row = new Db\Wopi();
+		$row->loadBy('token', $token);
 
-			$wopi = 'index.php/apps/richdocuments/wopi/files/' . $file->getId() . '_' . $this->settings->getSystemValue('instanceid') . '?access_token=' . $wopiToken;
-			$url = \OC::$server->getURLGenerator()->getAbsoluteURL($wopi);
+		$res = $row->getWopiForToken($token);
+		if ($res == false) {
+			$this->logger->debug('wopiPutFile(): getWopiForToken() failed.', ['app' => $this->appName]);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		}
 
-			$this->logoutUser();
-			return new JSONResponse([ 'Name' => $file->getName(), 'Url' => $url ], Http::STATUS_OK);
+		$canWrite = $res['attributes'] & WOPI::ATTR_CAN_UPDATE;
+		if (!$canWrite) {
+			$this->logger->debug('wopiPutFile(): getWopiForToken() failed.', ['app' => $this->appName]);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		}
+		// This call is made from loolwsd, so we need to initialize the
+		// session before we can make the user who opened the document
+		// login. This is necessary to make activity app register the
+		// change made to this file under this user's (editorid) name.
+		$this->loginUser($res['editor']);
+
+		// Set up the filesystem view for the owner (where the file actually is).
+		$userFolder = \OC::$server->getRootFolder()->getUserFolder($res['owner']);
+		$file = $userFolder->getById($fileId)[0];
+
+		// the new file needs to be installed in the current user dir
+		$userFolder = \OC::$server->getRootFolder()->getUserFolder($res['editor']);
+		$file = $userFolder->getById($fileId)[0];
+
+		$suggested = $this->request->getHeader('X-WOPI-SuggestedTarget');
+		$suggested = \iconv('utf-7', 'utf-8', $suggested);
+
+		$path = '';
+		if ($suggested[0] === '.') {
+			$path = \dirname($file->getPath()) . '/New File' . $suggested;
+		} elseif ($suggested[0] !== '/') {
+			$path = \dirname($file->getPath()) . '/' . $suggested;
 		} else {
-			$this->logoutUser();
+			$path = $userFolder->getPath() . $suggested;
+		}
+
+		if ($path === '') {
 			return [
-				'status' => 'success',
-				'LastModifiedTime' => Helper::toISO8601($mtime)
+				'status' => 'error',
+				'message' => 'Cannot create the file'
 			];
 		}
+
+		$root = \OC::$server->getRootFolder();
+
+		// create the folder first
+		if (!$root->nodeExists(\dirname($path))) {
+			$root->newFolder(\dirname($path));
+		}
+
+		// create a unique new file
+		$path = $root->getNonExistingName($path);
+		$root->newFile($path);
+		$file = $root->get($path);
+
+		// Read the contents of the file from the POST body and store.
+		$content = \fopen('php://input', 'r');
+		$this->logger->debug('wopiPutFile(): Storing file {fileId}, editor: {editor}, owner: {owner}.', [
+			'app' => $this->appName,
+			'fileId' => $fileId,
+			'editor' => $res['editor'],
+			'owner' => $res['owner']]);
+
+		if ($this->appConfig->encryptionEnabled()) {
+			// with encryption, change needs to be applied as unknown user
+			// this also means that changes wont be auditable
+			\OC_User::setIncognitoMode(true);
+		}
+
+		// Setup the FS which is needed to emit hooks (versioning).
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($res['editor']);
+		$file->putContent($content);
+		$mtime = $file->getMtime();
+
+		// generate a token for the new file (the user still has to be
+		// logged in)
+		$row = new Wopi();
+		$serverHost = $this->request->getServerProtocol() . '://' . $this->request->getServerHost();
+
+		$attributes = WOPI::ATTR_CAN_VIEW | WOPI::ATTR_CAN_UPDATE | WOPI::ATTR_CAN_DOWNLOAD | WOPI::ATTR_CAN_PRINT;
+		$wopiToken = $row->generateToken($file->getId(), $res['path'], 0, $attributes, $serverHost, $res['owner'], $res['editor']);
+
+		$wopi = 'index.php/apps/richdocuments/wopi/files/' . $file->getId() . '_' . $this->settings->getSystemValue('instanceid') . '?access_token=' . $wopiToken;
+		$url = \OC::$server->getURLGenerator()->getAbsoluteURL($wopi);
+
+		$this->logoutUser();
+		return new JSONResponse([ 'Name' => $file->getName(), 'Url' => $url ], Http::STATUS_OK);
 	}
 
 	/**

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -66,7 +66,7 @@ class SettingsController extends Controller {
 				'external_apps' => $this->appConfig->getAppValue('external_apps'),
 				'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
 				'menu_option' => $this->appConfig->getAppValue('menu_option'),
-				'user_encryption_enabled' => $this->appConfig->encryptionEnabled() ? 'true' : 'false',
+				'user_encryption_enabled' => $this->appConfig->userEncryptionEnabled() ? 'true' : 'false',
 				'secure_view_allowed' => $this->appConfig->enterpriseFeaturesEnabled() ? 'true' : 'false',
 				'secure_view_option' => $this->appConfig->getAppValue('secure_view_option'),
 				'secure_view_has_watermark_default' => $this->appConfig->getAppValue('secure_view_has_watermark_default'),

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -66,7 +66,7 @@ class SettingsController extends Controller {
 				'external_apps' => $this->appConfig->getAppValue('external_apps'),
 				'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
 				'menu_option' => $this->appConfig->getAppValue('menu_option'),
-				'encryption_enabled' => $this->appConfig->encryptionEnabled() ? 'true' : 'false',
+				'user_encryption_enabled' => $this->appConfig->encryptionEnabled() ? 'true' : 'false',
 				'secure_view_allowed' => $this->appConfig->enterpriseFeaturesEnabled() ? 'true' : 'false',
 				'secure_view_option' => $this->appConfig->getAppValue('secure_view_option'),
 				'secure_view_has_watermark_default' => $this->appConfig->getAppValue('secure_view_has_watermark_default'),

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -66,6 +66,7 @@ class SettingsController extends Controller {
 				'external_apps' => $this->appConfig->getAppValue('external_apps'),
 				'canonical_webroot' => $this->appConfig->getAppValue('canonical_webroot'),
 				'menu_option' => $this->appConfig->getAppValue('menu_option'),
+				'encryption_enabled' => $this->appConfig->encryptionEnabled() ? 'true' : 'false',
 				'secure_view_allowed' => $this->appConfig->enterpriseFeaturesEnabled() ? 'true' : 'false',
 				'secure_view_option' => $this->appConfig->getAppValue('secure_view_option'),
 				'secure_view_has_watermark_default' => $this->appConfig->getAppValue('secure_view_has_watermark_default'),

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -40,7 +40,6 @@ class Wopi extends \OCA\Richdocuments\Db {
 	 * Generate token for document being shared with public link
 	 *
 	 * @param $fileId
-	 * @param $path
 	 * @param $version
 	 * @param $attributes
 	 * @param $serverHost
@@ -49,18 +48,17 @@ class Wopi extends \OCA\Richdocuments\Db {
 	 * @return string
 	 * @throws \Exception
 	 */
-	public function generateToken($fileId, $path, $version, $attributes, $serverHost, $owner, $editor) {
+	public function generateToken($fileId, $version, $attributes, $serverHost, $owner, $editor) {
 		$token = \OC::$server->getSecureRandom()->getMediumStrengthGenerator()->generate(32,
 			\OCP\Security\ISecureRandom::CHAR_LOWER . \OCP\Security\ISecureRandom::CHAR_UPPER .
 			\OCP\Security\ISecureRandom::CHAR_DIGITS);
 
-		\OC::$server->getLogger()->debug('generateFileToken(): Issuing token, editor: {editor}, file: {fileId}, version: {version}, owner: {owner}, path: {path}, token: {token}', [
+		\OC::$server->getLogger()->debug('generateFileToken(): Issuing token, editor: {editor}, file: {fileId}, version: {version}, owner: {owner}, token: {token}', [
 			'app' => self::appName,
 			'owner' => $owner,
 			'editor' => $editor,
 			'fileId' => $fileId,
 			'version' => $version,
-			'path' => $path,
 			'token' => $token ]);
 
 		$wopi = new \OCA\Richdocuments\Db\Wopi([
@@ -68,7 +66,7 @@ class Wopi extends \OCA\Richdocuments\Db {
 			$editor,
 			$fileId,
 			$version,
-			$path,
+			'',
 			$attributes,
 			$serverHost,
 			$token,
@@ -110,7 +108,6 @@ class Wopi extends \OCA\Richdocuments\Db {
 		return [
 			'owner' => $row['owner_uid'],
 			'editor' => $row['editor_uid'],
-			'path' => $row['path'],
 			'attributes' => $row['attributes'],
 			'server_host' => $row['server_host']
 		];

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -31,8 +31,8 @@ class Wopi extends \OCA\Richdocuments\Db {
 
 	protected $tableName  = '`*PREFIX*richdocuments_wopi`';
 
-	protected $insertStatement  = 'INSERT INTO `*PREFIX*richdocuments_wopi` (`owner_uid`, `editor_uid`, `fileid`, `version`, `path`, `attributes`, `server_host`, `token`, `expiry`)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)';
+	protected $insertStatement  = 'INSERT INTO `*PREFIX*richdocuments_wopi` (`owner_uid`, `editor_uid`, `fileid`, `version`, `attributes`, `server_host`, `token`, `expiry`)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
 
 	protected $loadStatement = 'SELECT * FROM `*PREFIX*richdocuments_wopi` WHERE `token`= ?';
 
@@ -66,7 +66,6 @@ class Wopi extends \OCA\Richdocuments\Db {
 			$editor,
 			$fileId,
 			$version,
-			'',
 			$attributes,
 			$serverHost,
 			$token,

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -7,7 +7,10 @@ script('richdocuments', 'admin');
                 title="<?php p($l->t('Open documentation'));?>"
                 href="https://github.com/owncloud/richdocuments/wiki"></a>
 
-        <br/>
+    <br/>
+	<p style="max-width: 50em; color: red;"><?php if ($_['encryption_enabled'] === 'true') {
+	p($l->t("Encryption with master or user key is enabled, the changes made to the files by users will only be auditable within this app"));
+} ?></p>
 	<label for="wopi_url"><?php p($l->t('Collabora Online server')) ?></label>
 	<input type="text" name="wopi_url" id="wopi_url" value="<?php p($_['wopi_url'])?>" style="width:300px;">
 	<br/><em><?php p($l->t('URL (and port) of the Collabora Online server that provides the editing functionality as a WOPI client.')) ?></em>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -8,8 +8,8 @@ script('richdocuments', 'admin');
                 href="https://github.com/owncloud/richdocuments/wiki"></a>
 
     <br/>
-	<p style="max-width: 50em; color: red;"><?php if ($_['encryption_enabled'] === 'true') {
-	p($l->t("Encryption with master or user key is enabled, the changes made to the files by users will only be auditable within this app"));
+	<p style="max-width: 50em; color: red;"><?php if ($_['user_encryption_enabled'] === 'true') {
+	p($l->t("Encryption with user key is enabled (only supported is master key encryption). App requires priviledged access to the files, and user encryption enabled will result in limited functionality of the app."));
 } ?></p>
 	<label for="wopi_url"><?php p($l->t('Collabora Online server')) ?></label>
 	<input type="text" name="wopi_url" id="wopi_url" value="<?php p($_['wopi_url'])?>" style="width:300px;">


### PR DESCRIPTION
There were few problem with previous implementation:
- with encryption or without, all activity was not auditable (incognito mode by default)
- public link was set for editor as owner of the file
- non-uniform method for getting priviledged access to file from collabora
- it was not made clear to the admin that this app is "partially" compatible with user key encryption as this app requires priviledged access to the files (and password of user with which files are encrypted cannot retrieved)

This PR fixes it:

<img width="225" alt="coll2" src="https://user-images.githubusercontent.com/13368647/59980774-abe84780-95fa-11e9-8555-3365f91d4c8e.png">
<img width="345" alt="coll1" src="https://user-images.githubusercontent.com/13368647/59980775-abe84780-95fa-11e9-800f-b6a7f77f186c.png">

Tested:
- [x] [without encryption] edit as owner, edit as share receiver, edit as public link, move files around as share receiver, ensure activity is registered, ensure versions are correctly generated
- [x] [with master key encryption] edit as owner, edit as share receiver, edit as public link, move files around as share receiver, ensure activity is registered, ensure versions are correctly generated
- [x] [with user key encryption] settings page warning displayed, coediting already opened file, edit file from root folder (no moving around), public links work, ensure versions are correctly generated