### PR TITLE
[288] Hide instead of check settings print button without secure view

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -342,23 +342,26 @@ var documentsSettings = {
 
 		$(document).on('change', '#secure_view_has_watermark_default_option_cb-richdocuments', function() {
 			var page = $(this).parent();
+
+			// if secure-view checkbox got changed make sure print checkbox is checked
+			// and if secure-view unchecked print is disabled (click action disabled)
+			page.find('#secure_view_can_print_default_option_cb-richdocuments')
+				.prop('checked', true);
 			if (!this.checked) {
-				// to disable secure-view, print needs to be enabled
 				page.find('#secure_view_can_print_default_option_cb-richdocuments')
-					.prop('checked', true);
-				documentsSettings.saveCanPrintDefaultOption(true);
+					.prop('disabled', true);
+			} else {
+				page.find('#secure_view_can_print_default_option_cb-richdocuments')
+					.prop('disabled', false);
 			}
+
+			// save secure-view (changed) and print (true) options
+			documentsSettings.saveCanPrintDefaultOption(true);
 			documentsSettings.saveHasWatermarkDefaultOption(this.checked);
 		});
 
 		$(document).on('change', '#secure_view_can_print_default_option_cb-richdocuments', function() {
 			var page = $(this).parent();
-			if (!this.checked) {
-				// to disable print, secure-view needs to be enabled
-				page.find('#secure_view_has_watermark_default_option_cb-richdocuments')
-					.prop('checked', true);
-				documentsSettings.saveHasWatermarkDefaultOption(true);
-			}
 			documentsSettings.saveCanPrintDefaultOption(this.checked);
 		});
 

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -87,7 +87,7 @@ script('richdocuments', 'admin');
 	p('hidden');
 } ?>" >
 		<p style="max-width: 50em;"><em><?php p($l->t('Set default share permissions for all users (available for shares without edit permission)')) ?></em></p>
-		<input type="checkbox" id="secure_view_can_print_default_option_cb-richdocuments" <?php p($_['secure_view_can_print_default'] === 'true' ? 'checked' : '') ?> />
+		<input type="checkbox" id="secure_view_can_print_default_option_cb-richdocuments" <?php p($_['secure_view_can_print_default'] === 'true' ? 'checked' : '')  ?> <?php p($_['secure_view_has_watermark_default'] === 'false' ? 'disabled' : '')  ?>  />
 		<label for="secure_view_can_print_default_option_cb-richdocuments"><?php p($l->t('can print/export')) ?></label>
 		<br/>
 		<input type="checkbox" id="secure_view_has_watermark_default_option_cb-richdocuments" <?php p($_['secure_view_has_watermark_default'] === 'true' ? 'checked' : '') ?> />


### PR DESCRIPTION

<img width="673" alt="Screenshot at Oct 08 12-40-06" src="https://user-images.githubusercontent.com/13368647/66390211-7bba8e00-e9ca-11e9-9b59-3ca5c8e1c3c5.png">
<img width="578" alt="Screenshot at Oct 08 12-39-55" src="https://user-images.githubusercontent.com/13368647/66390212-7bba8e00-e9ca-11e9-9c33-8bf33d2ebb02.png">

Fixes https://github.com/owncloud/richdocuments/issues/288