### PR TITLE
Do not allow to open document if viewing is disabled

### DIFF
--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -22,10 +22,10 @@ class Wopi extends \OCA\Richdocuments\Db {
 	const TOKEN_LIFETIME_SECONDS = 1800;
 
 	const ATTR_CAN_VIEW = 0;
-	const ATTR_CAN_DOWNLOAD = 1;
-	const ATTR_CAN_PRINT = 2;
-	const ATTR_HAS_WATERMARK = 4;
-	const ATTR_CAN_UPDATE = 8;
+	const ATTR_CAN_UPDATE = 1;
+	const ATTR_CAN_EXPORT = 2;
+	const ATTR_CAN_PRINT = 4;
+	const ATTR_HAS_WATERMARK = 8;
 
 	const appName = 'richdocuments';
 

--- a/tests/acceptance/features/webUISecureView/main.feature
+++ b/tests/acceptance/features/webUISecureView/main.feature
@@ -65,10 +65,10 @@ Feature: Secure View
       | share_with             | user1          |
       | share_with_displayname | User One       |
     And the additional sharing attributes for the response should include
-      | scope         | key       | enabled |
-      | permissions   | download  | false   |
-      | richdocuments | watermark | true    |
-      | richdocuments | print     | false   |
+      | scope         | key                 | enabled |
+      | permissions   | download            | false   |
+      | richdocuments | view-with-watermark | true    |
+      | richdocuments | print               | false   |
     And the downloaded content when downloading file "simple-folder/lorem.txt" for user "user0" with range "bytes=0-17" should be "This is lorem text"
     And as "user1" file "simple-folder/lorem.txt" should exist
     But the downloading of file "simple-folder/lorem.txt" for user "user1" should fail with error message
@@ -102,10 +102,7 @@ Feature: Secure View
       | displayname_owner      | User Zero      |
       | share_with             | user1          |
       | share_with_displayname | User One       |
-    And the additional sharing attributes for the response should include
-      | scope         | key       | enabled |
-      | permissions   | download  | true    |
-      | richdocuments | watermark | false   |
+    And the additional sharing attributes for the response should be empty
     And the downloaded content when downloading file "simple-folder/lorem.txt" for user "user0" with range "bytes=0-17" should be "This is lorem text"
     And as "user1" file "simple-folder/lorem.txt" should exist
     And the downloaded content when downloading file "simple-folder/lorem.txt" for user "user1" with range "bytes=0-17" should be "This is lorem text"
@@ -138,10 +135,10 @@ Feature: Secure View
       | share_with             | user1          |
       | share_with_displayname | User One       |
     And the additional sharing attributes for the response should include
-      | scope         | key       | enabled |
-      | permissions   | download  | false   |
-      | richdocuments | watermark | true    |
-      | richdocuments | print     | true    |
+      | scope         | key                 | enabled |
+      | permissions   | download            | false   |
+      | richdocuments | view-with-watermark | true    |
+      | richdocuments | print               | true    |
     And the downloaded content when downloading file "simple-folder/lorem.txt" for user "user0" with range "bytes=0-17" should be "This is lorem text"
     And as "user1" file "simple-folder/lorem.txt" should exist
     But the downloading of file "simple-folder/lorem.txt" for user "user1" should fail with error message
@@ -175,10 +172,7 @@ Feature: Secure View
       | displayname_owner      | User Zero      |
       | share_with             | user1          |
       | share_with_displayname | User One       |
-    And the additional sharing attributes for the response should include
-      | scope         | key       | enabled |
-      | permissions   | download  | true    |
-      | richdocuments | watermark | false   |
+    And the additional sharing attributes for the response should be empty
     And the downloaded content when downloading file "simple-folder/lorem.txt" for user "user0" with range "bytes=0-17" should be "This is lorem text"
     And as "user1" file "simple-folder/lorem.txt" should exist
     And the downloaded content when downloading file "simple-folder/lorem.txt" for user "user1" with range "bytes=0-17" should be "This is lorem text"
@@ -211,10 +205,10 @@ Feature: Secure View
       | share_with             | user1          |
       | share_with_displayname | User One       |
     And the additional sharing attributes for the response should include
-      | scope         | key       | enabled |
-      | permissions   | download  | false   |
-      | richdocuments | watermark | true    |
-      | richdocuments | print     | true    |
+      | scope         | key                 | enabled |
+      | permissions   | download            | false   |
+      | richdocuments | view-with-watermark | true    |
+      | richdocuments | print               | true    |
     And the downloaded content when downloading file "simple-folder/lorem.txt" for user "user0" with range "bytes=0-17" should be "This is lorem text"
     And as "user1" file "simple-folder/lorem.txt" should exist
     But the downloading of file "simple-folder/lorem.txt" for user "user1" should fail with error message
@@ -250,10 +244,10 @@ Feature: Secure View
       | share_with             | user1          |
       | share_with_displayname | User One       |
     And the additional sharing attributes for the response should include
-      | scope         | key       | enabled |
-      | permissions   | download  | false   |
-      | richdocuments | watermark | true    |
-      | richdocuments | print     | false   |
+      | scope         | key                 | enabled |
+      | permissions   | download            | false   |
+      | richdocuments | view-with-watermark | true    |
+      | richdocuments | print               | false   |
     And the downloaded content when downloading file "simple-folder/lorem.txt" for user "user0" with range "bytes=0-17" should be "This is lorem text"
     And as "user1" file "simple-folder/lorem.txt" should exist
     But the downloading of file "simple-folder/lorem.txt" for user "user1" should fail with error message
@@ -320,10 +314,10 @@ Feature: Secure View
       | share_with             | user2          |
       | share_with_displayname | User Two       |
     And the additional sharing attributes for the response should include
-      | scope         | key       | enabled |
-      | permissions   | download  | false   |
-      | richdocuments | watermark | true    |
-      | richdocuments | print     | false   |
+      | scope         | key                 | enabled |
+      | permissions   | download            | false   |
+      | richdocuments | view-with-watermark | true    |
+      | richdocuments | print               | false   |
     And the user sets the sharing permissions of user "User Two" for "simple-folder" using the webUI to
       | share        | yes |
     And user "user1" gets the info of the last share using the sharing API


### PR DESCRIPTION
Do not allow to open document in Collabora if both download and viewing (e.g. with watermark) is disabled. 

- [x] strict permission checks
- [x] adjust integration tests

Cases considered:
- user receives a share with `download->false` and `view-with-watermark->true`: user can view (with watermark) the file in the editor, but cannot download to disk. 
- user receives a share with `download->false` and `view-with-watermark->false`: user cannot view the file nor download to disk (insufficient permission exception)
- user receives a share with `view-with-watermark->false`:  user cannot open editor due to viewing restriction being set to false (insufficient permission exception)
- user receives a share with `download->false`:  user can open editor with no watermark, but cannot export/download file

<img width="766" alt="Screenshot at Oct 08 20-22-34" src="https://user-images.githubusercontent.com/13368647/66422512-1be3d780-ea0a-11e9-8b5f-efcb61649576.png">