### PR TITLE
No need to test against 10.3.0 any more

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -63,7 +63,7 @@ config = {
 		'acceptance': {
 			'servers': [
 				'daily-master-qa',
-				'10.3.0'
+				'latest'
 			],
 		}
 	}

--- a/.drone.yml
+++ b/.drone.yml
@@ -1699,7 +1699,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUISecV-10.3.0-chrome-mariadb10.2-php7.0
+name: webUISecV-latest-chrome-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -1721,7 +1721,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/richdocuments
-    version: 10.3.0
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -1817,7 +1817,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUISecV-10.3.0-chrome-mariadb10.2-php7.1
+name: webUISecV-latest-chrome-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -1839,7 +1839,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/richdocuments
-    version: 10.3.0
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -1935,7 +1935,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUISecV-10.3.0-chrome-mariadb10.2-php7.2
+name: webUISecV-latest-chrome-mariadb10.2-php7.2
 
 platform:
   os: linux
@@ -1957,7 +1957,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/richdocuments
-    version: 10.3.0
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -2053,7 +2053,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUISecV-10.3.0-chrome-mariadb10.2-php7.3
+name: webUISecV-latest-chrome-mariadb10.2-php7.3
 
 platform:
   os: linux
@@ -2075,7 +2075,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/richdocuments
-    version: 10.3.0
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -2171,7 +2171,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUISecV-10.3.0-firefox-mariadb10.2-php7.0
+name: webUISecV-latest-firefox-mariadb10.2-php7.0
 
 platform:
   os: linux
@@ -2193,7 +2193,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/richdocuments
-    version: 10.3.0
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -2290,7 +2290,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUISecV-10.3.0-firefox-mariadb10.2-php7.1
+name: webUISecV-latest-firefox-mariadb10.2-php7.1
 
 platform:
   os: linux
@@ -2312,7 +2312,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/richdocuments
-    version: 10.3.0
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -2409,7 +2409,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUISecV-10.3.0-firefox-mariadb10.2-php7.2
+name: webUISecV-latest-firefox-mariadb10.2-php7.2
 
 platform:
   os: linux
@@ -2431,7 +2431,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/richdocuments
-    version: 10.3.0
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -2528,7 +2528,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: webUISecV-10.3.0-firefox-mariadb10.2-php7.3
+name: webUISecV-latest-firefox-mariadb10.2-php7.3
 
 platform:
   os: linux
@@ -2550,7 +2550,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/richdocuments
-    version: 10.3.0
+    version: latest
 
 - name: install-testrunner
   pull: always
@@ -2691,13 +2691,13 @@ depends_on:
 - webUISecV-master-firefox-mariadb10.2-php7.1
 - webUISecV-master-firefox-mariadb10.2-php7.2
 - webUISecV-master-firefox-mariadb10.2-php7.3
-- webUISecV-10.3.0-chrome-mariadb10.2-php7.0
-- webUISecV-10.3.0-chrome-mariadb10.2-php7.1
-- webUISecV-10.3.0-chrome-mariadb10.2-php7.2
-- webUISecV-10.3.0-chrome-mariadb10.2-php7.3
-- webUISecV-10.3.0-firefox-mariadb10.2-php7.0
-- webUISecV-10.3.0-firefox-mariadb10.2-php7.1
-- webUISecV-10.3.0-firefox-mariadb10.2-php7.2
-- webUISecV-10.3.0-firefox-mariadb10.2-php7.3
+- webUISecV-latest-chrome-mariadb10.2-php7.0
+- webUISecV-latest-chrome-mariadb10.2-php7.1
+- webUISecV-latest-chrome-mariadb10.2-php7.2
+- webUISecV-latest-chrome-mariadb10.2-php7.3
+- webUISecV-latest-firefox-mariadb10.2-php7.0
+- webUISecV-latest-firefox-mariadb10.2-php7.1
+- webUISecV-latest-firefox-mariadb10.2-php7.2
+- webUISecV-latest-firefox-mariadb10.2-php7.3
 
 ...


### PR DESCRIPTION
The download link `latest` now points to the recent `10.3.0` release tarball. So test against latest.