### PR TITLE
Add sabre/xml to behat dependencies

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1221,10 +1221,7 @@ def installTestrunner(phpVersion, useBundledApp):
 			'rsync -aIX /tmp/testrunner /var/www/owncloud',
 		] + ([
 			'cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % config['app']
-		] if not useBundledApp else []) + [
-			'cd /var/www/owncloud/testrunner',
-			'make install-composer-deps'
-		]
+		] if not useBundledApp else [])
 	}]
 
 def installExtraApps(phpVersion, extraApps):

--- a/.drone.yml
+++ b/.drone.yml
@@ -682,8 +682,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/richdocuments /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-richdocuments
   pull: always
@@ -799,8 +797,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/richdocuments /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-richdocuments
   pull: always
@@ -916,8 +912,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/richdocuments /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-richdocuments
   pull: always
@@ -1033,8 +1027,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/richdocuments /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-richdocuments
   pull: always
@@ -1151,8 +1143,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/richdocuments /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-richdocuments
   pull: always
@@ -1269,8 +1259,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/richdocuments /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-richdocuments
   pull: always
@@ -1387,8 +1375,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/richdocuments /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-richdocuments
   pull: always
@@ -1504,8 +1490,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/richdocuments /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-richdocuments
   pull: always
@@ -1621,8 +1605,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/richdocuments /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-richdocuments
   pull: always
@@ -1738,8 +1720,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/richdocuments /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-richdocuments
   pull: always
@@ -1856,8 +1836,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/richdocuments /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-richdocuments
   pull: always
@@ -1974,8 +1952,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/richdocuments /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-richdocuments
   pull: always

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -13,6 +13,7 @@
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.0",
         "symfony/translation": "^3.4",
+        "sabre/xml": "^2.1",
         "guzzlehttp/guzzle": "^5.3",
         "phpunit/phpunit": "^7.5"
     }


### PR DESCRIPTION
It is needed by core `HttpRequestHelper.php` `parseResponseAsXml`

And there is no longer any need to `make install-composer-deps` in the testrunner core folder, because those dependencies are not used by behat any more.