### PR TITLE
Do not update permissions or attributes if other share fields gets updated

### DIFF
--- a/js/viewer/shareoptions.js
+++ b/js/viewer/shareoptions.js
@@ -77,13 +77,17 @@ var RichdocumentsShareOptions = {
 	 * @param properties
 	 */
 	updateShareProperties: function(shareId, properties) {
-		var that = this;
+		if (_.isUndefined(properties.permissions) && _.isUndefined(properties.attributes)) {
+			// no attribute or permission change, ignore
+			return properties;
+		}
+
 		var updatedProperties = properties;
 		updatedProperties.attributes = properties.attributes || {};
 
 		// if download permission got disabled, enable secure-view
 		// feature (allow viewing, but only with watermark)
-		var canDownloadAttr = that._getAttribute(properties.attributes, "permissions", "download");
+		var canDownloadAttr = this._getAttribute(properties.attributes, "permissions", "download");
 		if (canDownloadAttr && canDownloadAttr.enabled === false) {
 			updatedProperties.attributes = this._updateAttributes(
 				updatedProperties.attributes, "richdocuments", "view-with-watermark", true
@@ -99,7 +103,7 @@ var RichdocumentsShareOptions = {
 		updatedProperties.attributes = this._updateAttributes(
 			updatedProperties.attributes, "permissions", "download", null
 		);
-		updatedProperties.attributes = that._updateAttributes(
+		updatedProperties.attributes = this._updateAttributes(
 			updatedProperties.attributes, "richdocuments", "view-with-watermark", null
 		);
 		updatedProperties.attributes = this._updateAttributes(

--- a/tests/acceptance/features/webUISecureView/main.feature
+++ b/tests/acceptance/features/webUISecureView/main.feature
@@ -293,7 +293,7 @@ Feature: Secure View
     And the additional sharing attributes for the response should be empty
 
   @skipOnOcV10.3 @issue-enterprise-3441
-  Scenario: When reshare a file with secure-view enabled by default, receiver has secure-view enabled by default
+  Scenario: When resharing a folder and secure-view is enabled by default, receiver has secure-view enabled by default
     Given the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
     And user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
@@ -317,6 +317,7 @@ Feature: Secure View
     Then the fields of the last response should include
       | permissions            | read           |
     And the additional sharing attributes for the response should include
+      | scope         | key                 | enabled |
       | permissions   | download            | false   |
       | richdocuments | view-with-watermark | true    |
       | richdocuments | print               | false   |

--- a/tests/acceptance/features/webUISecureView/main.feature
+++ b/tests/acceptance/features/webUISecureView/main.feature
@@ -293,7 +293,7 @@ Feature: Secure View
     And the additional sharing attributes for the response should be empty
 
   @skipOnOcV10.3 @issue-enterprise-3441
-  Scenario: Reshare in secure-view is disabled
+  Scenario: When reshare a file with secure-view enabled by default, receiver has secure-view enabled by default
     Given the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
     And user "user0" has been created with default attributes and skeleton files
     And user "user1" has been created with default attributes and without skeleton files
@@ -313,8 +313,13 @@ Feature: Secure View
     And the additional sharing attributes for the response should be empty
     And the user re-logs in as "user1" using the webUI
     And the user shares folder "simple-folder" with user "User Two" using the webUI
-    Then a notification should be displayed on the webUI with the text 'Cannot set the requested share attributes for simple-folder'
-    And as "user2" folder "/simple-folder" should not exist
+    And user "user1" gets the info of the last share using the sharing API
+    Then the fields of the last response should include
+      | permissions            | read           |
+    And the additional sharing attributes for the response should include
+      | permissions   | download            | false   |
+      | richdocuments | view-with-watermark | true    |
+      | richdocuments | print               | false   |
 
   @skipOnOcV10.3 @issue-enterprise-3441
   Scenario: Reshare in secure-view is disabled for previous share even after share permission


### PR DESCRIPTION
Update share can update any field in share interface separately. This MR ensures that attributes get updated only if attribute or permission fields got updated.

- [ ] wait until 10.4.0-rc2 gets released to test manually  