### PR TITLE
Remove ownCloud's header

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -176,7 +176,7 @@
 	width:100%;
 	z-index: 500;
 	background-color: #ddd !important;
-	top: 45px;
+	top: 0;
 	bottom: 0;
 }
 

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -351,7 +351,7 @@ class DocumentController extends Controller {
 		}
 		$retVal = \array_merge($retVal, $docRetVal);
 
-		$response = new TemplateResponse('richdocuments', 'documents', $retVal);
+		$response = new TemplateResponse('richdocuments', 'documents', $retVal, 'base');
 		$policy = new ContentSecurityPolicy();
 		$policy->addAllowedFrameDomain($this->domainOnly($wopiRemote));
 		$policy->allowInlineScript(true);


### PR DESCRIPTION
Related to https://github.com/owncloud/enterprise/issues/3723

Remove the ownCloud's header as shown in https://github.com/owncloud/enterprise/issues/3723#issuecomment-589075643
This affects both to public links and "normal document show" by registered users