### PR TITLE
Exclude drone.star from release tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,7 @@ appstore:
 	--exclude=.git \
 	--exclude=.phan \
 	--exclude=build \
-	--exclude=.drone.starlark \
-	--exclude=.drone.yml \
+	--exclude=.drone.star \
 	--exclude=.gitignore \
 	--exclude=.php_cs.cache \
 	--exclude=.php_cs.dist \


### PR DESCRIPTION
PR #318 moved `.drone.starlark` to `.drone.star` but missed that it was mentioned in `Makefile`

Adjust `Makefile`

(there does not seem to be a `release-2.3.0` branch in this repo, so this PR is to `master`)