### PR TITLE
add a background job for deleting expired tokens

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,4 +26,7 @@ You can also edit your documents off-line with the Collabora Office app from the
 	<screenshot>https://owncloud.com/wp-content/uploads/2016/07/code_v2_impress-1-1024x576.png</screenshot>
 	<ocsid>174727</ocsid>
 	<use-migrations>true</use-migrations>
+	<background-jobs>
+		<job>OCA\Richdocuments\BackgroundJob\CleanupExpiredWopiTokens</job>
+	</background-jobs>
 </info>

--- a/lib/BackgroundJob/CleanupExpiredWopiTokens.php
+++ b/lib/BackgroundJob/CleanupExpiredWopiTokens.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Richdocuments\BackgroundJob;
+
+use OC\BackgroundJob\TimedJob;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IDBConnection;
+
+class CleanupExpiredWopiTokens extends TimedJob {
+
+	/**
+	 * @var IDBConnection $connection
+	 */
+	protected $connection;
+
+	/**
+	 * @var ITimeFactory $timeFactory
+	 */
+	protected $timeFactory;
+
+	/**
+	 * @param IDBConnection $connection
+	 * @param ITimeFactory $timeFactory
+	 */
+	public function __construct(IDBConnection $connection, ITimeFactory $timeFactory) {
+		$this->connection = $connection;
+		$this->timeFactory = $timeFactory;
+	}
+
+	/**
+	 * Makes the background job do its work
+	 *
+	 * @param array $argument unused argument
+	 */
+	public function run($argument) {
+		$now = $this->timeFactory->getTime();
+		$this->connection->executeUpdate('DELETE FROM `*PREFIX*richdocuments_wopi` WHERE `expiry` <= ?',
+			[$now]
+		);
+	}
+}

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -877,6 +877,10 @@ class DocumentController extends Controller {
 
 		//TODO: Support X-WOPIMaxExpectedSize header.
 		$res = $row->getWopiForToken($token);
+		if ($res == false) {
+			$this->logger->debug('wopiGetFile(): getWopiForToken() failed.', ['app' => $this->appName]);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		}
 
 		$file = $this->getFileHandle($fileId, $res['owner'], $res['editor']);
 		if (!$file) {

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -79,10 +79,9 @@ class Wopi extends \OCA\Richdocuments\Db {
 		return $token;
 	}
 
-	/*
-	 * Given a token, validates it and
-	 * constructs and validates the path.
-	 * Returns the path, if valid, else false.
+	/**
+	 * @param string $token
+	 * @return array | false for invalid token
 	 */
 	public function getWopiForToken($token) {
 		$wopi = new Wopi();
@@ -90,18 +89,8 @@ class Wopi extends \OCA\Richdocuments\Db {
 		\OC::$server->getLogger()->debug('Loaded WOPI Token record: {row}.', [
 			'app' => self::appName,
 			'row' => $row ]);
-		if (\count($row) == 0) {
-			// Invalid token.
-			\http_response_code(401);
+		if (\count($row) == 0 || $row['expiry'] <= \time()) {
 			return false;
-		}
-
-		//TODO: validate.
-		if ($row['expiry'] > \time()) {
-			// Expired token!
-			//http_response_code(404);
-			//$wopi->deleteBy('id', $row['id']);
-			//return false;
 		}
 
 		return [

--- a/tests/unit/BackgroundJob/CleanupExpiredWopiTokensTest.php
+++ b/tests/unit/BackgroundJob/CleanupExpiredWopiTokensTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *
+ * @copyright Copyright (c) 2020, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Richdocuments\Tests\BackgroundJob;
+
+use OCA\Richdocuments\BackgroundJob\CleanupExpiredWopiTokens;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IDBConnection;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class CleanupExpiredWopiTokensTest extends TestCase {
+
+	/**
+	 * @var CleanupExpiredWopiTokens $job
+	 */
+	protected $job;
+
+	/**
+	 * @var IDBConnection | MockObject
+	 */
+	protected $connection;
+
+	/**
+	 * @var ITimeFactory | MockObject
+	 */
+	protected $timeFactory;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->connection = $this->createMock(IDBConnection::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+		$this->job = new CleanupExpiredWopiTokens($this->connection, $this->timeFactory);
+	}
+
+	public function testRun() {
+		$this->timeFactory->expects($this->once())
+			->method('getTime')
+			->willReturn(1000);
+		$this->connection->expects($this->once())
+			->method('executeUpdate')
+			->with('DELETE FROM `*PREFIX*richdocuments_wopi` WHERE `expiry` <= ?', [1000]);
+
+		$this->job->run([]);
+	}
+}


### PR DESCRIPTION
No need to hold expired tokens in database, this pr adds a background job for cleaning those tokens.

Fixes #https://github.com/owncloud/enterprise/issues/3732