### PR TITLE
[Tests-Only] Revert "Only run acceptance tests PHP 7.4 against daily core"

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -49,28 +49,11 @@ config = {
 			'phpVersions': [
 				'7.2',
 				'7.3',
-			],
-			'browsers': [
-				'chrome',
-				'firefox'
-			],
-			'servers': [
-				'daily-master-qa',
-			],
-		},
-		'webUI74': {
-			'suites': {
-				'webUISecureView': 'webUISecV',
-			},
-			'phpVersions': [
 				'7.4',
 			],
 			'browsers': [
 				'chrome',
 				'firefox'
-			],
-			'servers': [
-				'daily-master-qa',
 			],
 		},
 	},


### PR DESCRIPTION
This reverts commit 63c9b3625cf0d1aa6cbf0f0bbdc97336308e3d6c.

core `latest` is now a 10.5.0 tarball, so we can test against it.

Note: while resolving conflicts for this revert, I have also effectively reverted https://github.com/owncloud/richdocuments/commit/9bdb5c2b2731180f3ce7bc07f2e8f73e7e370726 and sorted out removing the specific `servers` list from `acceptance` `webUI` - the list that we want is already the default.