### PR TITLE
Add warning for secure view regarding license

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -89,21 +89,12 @@ class AppConfig {
 	 * @return bool
 	 */
 	public function enterpriseFeaturesEnabled() {
-		$isEnterprise = $this->config->getAppValue($this->appName, 'isEEActive', null);
-		if ($isEnterprise === null) {
-			// app not marked as EE -> return false without doing anything more
-			return false;
-		}
-
-		$isEnterprise = \filter_var($isEnterprise, FILTER_VALIDATE_BOOLEAN);
-		if (!$isEnterprise || !$this->licenseManager->checkLicenseFor($this->appName)) {
-			// if not marked as enterprise, no need to check the license:
-			// explicitly mark the app as non-enterprise and remove the secure view.
-			// if marked as enterprise, we need to verify the license
-			$this->config->setAppValue($this->appName, 'isEEActive', 'no');
-			$this->config->setAppValue($this->appName, 'secure_view_option', 'false');
-			return false;
-		}
+		/**
+		 * FIXME: this needs to be changed when 10.6 is released with license fix
+		 *
+		 * We need here to check for version \OC_Util::getVersion() (if this fix is going to be only richdocuments patch release),
+		 * and do $this->licenseManager->checkLicenseFor($this->appName, $options)
+		 */
 
 		return true;
 	}

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -81,7 +81,8 @@ script('richdocuments', 'admin');
 	p($l->t('Enable Secure View (requires Enterprise edition)'));
 	print_unescaped('</em>');
 } else {
-	p($l->t('Enable Secure View'));
+	//FIXME: in 10.6 we wont need to warn about requring enterprise edition, but just disable checkbox
+	p($l->t('Enable Secure View (requires Enterprise edition)'));
 }?></label>
 	<div id="enable-share-attributes-defaults" style="padding-left: 28px;" class="indent <?php if ($_['secure_view_option'] !== 'true') {
 	p('hidden');

--- a/tests/acceptance/features/webUISecureView/main.feature
+++ b/tests/acceptance/features/webUISecureView/main.feature
@@ -5,30 +5,26 @@ Feature: Secure View
   So that users can share files with very restricted access to documents
 
   Scenario: Admin enables the secure view through webUI
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has browsed to the admin additional settings page
+    Given the administrator has browsed to the admin additional settings page
     When the administrator enables secure view using the webUI
     Then the config key "secure_view_option" of app "richdocuments" should have value "true"
 
   Scenario: Admin enables the secure view, enabled print permissions through webUI
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has browsed to the admin additional settings page
+    Given the administrator has browsed to the admin additional settings page
     When the administrator enables secure view using the webUI
     And the administrator enables print permission in secure view using the webUI
     Then the config key "secure_view_option" of app "richdocuments" should have value "true"
     And the config key "secure_view_can_print_default" of app "richdocuments" should have value "true"
 
   Scenario: Admin enables the secure view, disables secure-view permissions through webUI
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has browsed to the admin additional settings page
+    Given the administrator has browsed to the admin additional settings page
     When the administrator enables secure view using the webUI
     And the administrator disables watermark permission in secure view using the webUI
     Then the config key "secure_view_option" of app "richdocuments" should have value "true"
     And the config key "secure_view_has_watermark_default" of app "richdocuments" should have value "false"
 
   Scenario: Admin enables the secure view using occ command, disables print default and enables it again through webUI
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
+    Given the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
     And the administrator has added config key "secure_view_can_print_default" with value "false" in app "richdocuments"
     And the administrator has browsed to the admin additional settings page
     When the administrator enables print permission in secure view using the webUI
@@ -36,8 +32,7 @@ Feature: Secure View
     And the config key "secure_view_can_print_default" of app "richdocuments" should have value "true"
 
   Scenario: Admin enables the secure view using occ command, disables secure-view default and enables it again through webUI
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
+    Given the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
     And the administrator has added config key "secure_view_has_watermark_default" with value "false" in app "richdocuments"
     And the administrator has browsed to the admin additional settings page
     When the administrator enables watermark permission in secure view using the webUI
@@ -46,8 +41,7 @@ Feature: Secure View
 
   @skipOnOcV10.3
   Scenario: Admin enables secure view, user shares without edit permissions with default secure view permissions set and resharing disabled
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
+    Given the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
     And user "Alice" has been created with default attributes and skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
@@ -85,8 +79,7 @@ Feature: Secure View
 
   @skipOnOcV10.3
   Scenario: Admin enables secure view, disables secure-view default and user shares without edit permissions with default secure view permissions set and resharing disabled
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
+    Given the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
     And the administrator has added config key "secure_view_has_watermark_default" with value "false" in app "richdocuments"
     And user "Alice" has been created with default attributes and skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -118,8 +111,7 @@ Feature: Secure View
 
   @skipOnOcV10.3
   Scenario: Admin enables secure view, enables secure-view default and enables print default and user shares without edit permissions with default secure view permissions set and resharing disabled
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
+    Given the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
     And the administrator has added config key "secure_view_has_watermark_default" with value "true" in app "richdocuments"
     And the administrator has added config key "secure_view_can_print_default" with value "true" in app "richdocuments"
     And user "Alice" has been created with default attributes and skeleton files
@@ -159,8 +151,7 @@ Feature: Secure View
 
   @skipOnOcV10.3
   Scenario: Admin enables secure view and user shares without edit permissions and with secure-view disabled
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
+    Given the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
     And user "Alice" has been created with default attributes and skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
@@ -192,8 +183,7 @@ Feature: Secure View
 
   @skipOnOcV10.3
   Scenario: Admin enables secure view and user shares without edit permissions and with secure view enabled and print enabled
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
+    Given the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
     And user "Alice" has been created with default attributes and skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
@@ -233,8 +223,7 @@ Feature: Secure View
 
   @skipOnOcV10.3
   Scenario: Admin enables secure view and user shares without edit permissions and with secure view enabled and print disabled
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
+    Given the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
     And user "Alice" has been created with default attributes and skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has logged in using the webUI
@@ -275,8 +264,7 @@ Feature: Secure View
   @skipOnOcV10.3
   @issue-enterprise-3441
   Scenario: Admin enables secure view and user shares with reshare permission and no edit permission, secure-view is not available to be set for the share
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
+    Given the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
     And user "Alice" has been created with default attributes and skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
@@ -306,8 +294,7 @@ Feature: Secure View
 
   @skipOnOcV10.3 @issue-enterprise-3441
   Scenario: When resharing a folder and secure-view is enabled by default, receiver has secure-view enabled by default
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
+    Given the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
     And user "Alice" has been created with default attributes and skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
@@ -337,8 +324,7 @@ Feature: Secure View
 
   @skipOnOcV10.3 @issue-enterprise-3441
   Scenario: Reshare in secure-view is disabled for previous share even after share permission
-    Given the administrator has added config key "isEEActive" with value "yes" in app "richdocuments"
-    And the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
+    Given the administrator has added config key "secure_view_option" with value "true" in app "richdocuments"
     And user "Alice" has been created with default attributes and skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files

--- a/tests/unit/AppConfigTest.php
+++ b/tests/unit/AppConfigTest.php
@@ -51,13 +51,10 @@ class AppConfigTest extends TestCase {
 	}
 
 	public function testSecureViewDisabled() {
-		$this->config->method('getAppValue')
-			->willReturn('true');
-		$this->licenseManager->method('checkLicenseFor')
-			->willReturn(false);
-		$value = $this->appConfig->getAppValue('open_in_new_tab');
+		// TODO: This is currently aligned with the changes at the moment.
+		// we've decided to release secure_view as community in this version
+		// until a new core release fixes the problem with the license.
 		$enterpriseEdition = $this->appConfig->enterpriseFeaturesEnabled();
-		$this->assertEquals('true', $value);
-		$this->assertEquals(false, $enterpriseEdition);
+		$this->assertEquals(true, $enterpriseEdition);
 	}
 }


### PR DESCRIPTION

<img width="632" alt="Zrzut ekranu 2020-08-16 o 10 31 34" src="https://user-images.githubusercontent.com/13368647/90330364-96776f00-dfac-11ea-8b6c-e9f5c589b6b4.png">


- [x] reverts https://github.com/owncloud/richdocuments/pull/354
- [x] add just a warning, needs to be fixed properly with https://github.com/owncloud/core/pull/37813, and later check for version plus proper license-checking done as part of 2.4.2 or 2.5.0 

target 2.4.1