### PR TITLE
expire wopi token after 10 hours as suggested in the project docs

### DIFF
--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -19,7 +19,7 @@ namespace OCA\Richdocuments\Db;
 
 class Wopi extends \OCA\Richdocuments\Db {
 	// Tokens expire after this many seconds (not defined by WOPI specs).
-	const TOKEN_LIFETIME_SECONDS = 1800;
+	const TOKEN_LIFETIME_SECONDS = 36000;
 
 	const ATTR_CAN_VIEW = 0;
 	const ATTR_CAN_UPDATE = 1;


### PR DESCRIPTION
This PR extends `access_token_ttl` from 30 minutes to 10 hours which is recommended duration in the following wopi's document:
https://wopi.readthedocs.io/projects/wopirest/en/latest/concepts.html#term-access-token-ttl
![resim](https://user-images.githubusercontent.com/14157973/96386661-3c11af00-11a5-11eb-94a2-b0c7a909e74e.png)

In this way, it will help to reduce early token expiration problem mentioned in https://github.com/owncloud/enterprise/issues/4237