### PR TITLE
Fix if statement reported by phpstan

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -75,7 +75,7 @@ class DocumentController extends Controller {
 		}
 
 		$result = $discovery_parsed->xpath(\sprintf('/wopi-discovery/net-zone/app[@name=\'%s\']/action', $mimetype));
-		if ($result && \count($result) > 0) {
+		if (($result !== false) && (\count($result) > 0)) {
 			return [
 				'urlsrc' => (string)$result[0]['urlsrc'],
 				'action' => (string)$result[0]['name']

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 parameters:
   inferPrivatePropertyTypeFromConstructor: true
-  bootstrap: %currentWorkingDirectory%/../../lib/base.php
+  bootstrapFiles:
+    - %currentWorkingDirectory%/../../lib/base.php
   excludes_analyse:
     - %currentWorkingDirectory%/appinfo/Migrations/*.php
     - %currentWorkingDirectory%/appinfo/routes.php


### PR DESCRIPTION
The latest release of phpstan reports:
```
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
⚠️  You're using a deprecated config option bootstrap. ⚠️️

This option has been replaced with bootstrapFiles which accepts a list of files
to execute before the analysis.

 ------ -------------------------------------------------------------------- 
  Line   lib/Controller/DocumentController.php                               
 ------ -------------------------------------------------------------------- 
  78     Comparison operation ">" between int<1, max> and 0 is always true.  
 ------ -------------------------------------------------------------------- 

                                                                                                                        
 [ERROR] Found 1 error                                                                          
```

1) Adjust the `if` statement to have a more strict comparison
2) update the phpstan setting to use `bootstrapFiles`
