### PR TITLE
pass access token ttl value to wopi client

### DIFF
--- a/js/documents.js
+++ b/js/documents.js
@@ -265,11 +265,14 @@ var documentsMain = {
 			    "&permission=readonly";
 
 			// access_token - must be passed via a form post
-			var access_token = encodeURIComponent(documentsMain.token);
+			var access_token = encodeURIComponent(documentsMain.accessToken);
+			var access_token_ttl = encodeURIComponent(documentsMain.accessTokenTtl);
 
-			// form to post the access token for WOPISrc
+			// form to post the access token and access_token_ttl for WOPISrc
 			var form = '<form id="loleafletform_viewer" name="loleafletform_viewer" target="loleafletframe_viewer" action="' + urlsrc + '" method="post">' +
-			    '<input name="access_token" value="' + access_token + '" type="hidden"/></form>';
+			    '<input name="access_token" value="' + access_token + '" type="hidden"/>' +
+			    '<input name="access_token_ttl" value="' + access_token_ttl + '" type="hidden"/>' +
+			    '</form>';
 
 			// iframe that contains the Collabora Online Viewer
 			var frame = '<iframe id="loleafletframe_viewer" name= "loleafletframe_viewer" style="width:100%;height:100%;position:absolute;"/>';
@@ -460,11 +463,14 @@ var documentsMain = {
 			}
 
 			// access_token - must be passed via a form post
-			var access_token = encodeURIComponent(rd_token);
+			var access_token = encodeURIComponent(documentsMain.accessToken);
+			var access_token_ttl = encodeURIComponent(documentsMain.accessTokenTtl);
 
-			// form to post the access token for WOPISrc
+			// form to post the access token and access_token_ttl for WOPISrc
 			var form = '<form id="loleafletform" name="loleafletform" target="loleafletframe" action="' + urlsrc + '" method="post">' +
-			    '<input name="access_token" value="' + access_token + '" type="hidden"/></form>';
+			    '<input name="access_token" value="' + access_token + '" type="hidden"/>' +
+			    '<input name="access_token_ttl" value="' + access_token_ttl + '" type="hidden"/>' +
+			    '</form>';
 
 			// iframe that contains the Collabora Online
 			var frame = '<iframe id="loleafletframe" name= "loleafletframe" allowfullscreen style="width:100%;height:100%;position:absolute;" onload="this.contentWindow.focus()"/>';
@@ -665,7 +671,8 @@ var documentsMain = {
 	initSession: function() {
 		documentsMain.urlsrc = rd_urlsrc;
 		documentsMain.fullPath = rd_path;
-		documentsMain.token = rd_token;
+		documentsMain.accessToken = rd_access_token;
+		documentsMain.accessTokenTtl = rd_access_token_ttl;
 
 		$(documentsMain.toolbar).appendTo('#header');
 

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -435,7 +435,8 @@ class DocumentController extends Controller {
 			'instanceId' => $doc['instanceid'],
 			'version' => $doc['version'],
 			'sessionId' => $wopiInfo['sessionid'],
-			'token' => $wopiInfo['token'],
+			'access_token' => $wopiInfo['access_token'],
+			'access_token_ttl' => $wopiInfo['access_token_ttl'],
 			'urlsrc' => $doc['urlsrc'],
 			'path' => $doc['path']
 		];
@@ -657,12 +658,13 @@ class DocumentController extends Controller {
 		$this->updateDocumentEncryptionAccessList($owner, $currentUser, $path);
 
 		$row = new Db\Wopi();
-		$token = $row->generateToken($fileId, $version, $attributes, $serverHost, $owner, $currentUser);
+		$tokenArray = $row->generateToken($fileId, $version, $attributes, $serverHost, $owner, $currentUser);
 
 		// Return the token.
 		$result = [
 			'status' => 'success',
-			'token' => $token,
+			'access_token' => $tokenArray['access_token'],
+			'access_token_ttl' => $tokenArray['access_token_ttl'],
 			'sessionid' => $sessionid
 		];
 		$this->logger->debug('getWopiInfoForAuthUser(): Issued token: {result}', ['app' => $this->appName, 'result' => $result]);
@@ -731,12 +733,13 @@ class DocumentController extends Controller {
 		}
 
 		$row = new Db\Wopi();
-		$token = $row->generateToken($fileId, $version, $attributes, $serverHost, $ownerUid, $currentUser);
+		$tokenArray = $row->generateToken($fileId, $version, $attributes, $serverHost, $ownerUid, $currentUser);
 
 		// Return the token.
 		$result = [
 			'status' => 'success',
-			'token' => $token,
+			'access_token' => $tokenArray['access_token'],
+			'access_token_ttl' => $tokenArray['access_token_ttl'],
 			'sessionid' => '0' // default shared session
 		];
 		$this->logger->debug('getWopiInfoForPublicLink(): Issued token: {result}', ['app' => $this->appName, 'result' => $result]);
@@ -1096,9 +1099,9 @@ class DocumentController extends Controller {
 
 		// Continue editing
 		$attributes = WOPI::ATTR_CAN_VIEW | WOPI::ATTR_CAN_UPDATE | WOPI::ATTR_CAN_PRINT;
-		$wopiToken = $row->generateToken($file->getId(), 0, $attributes, $serverHost, $owner, $editor);
+		$tokenArray = $row->generateToken($file->getId(), 0, $attributes, $serverHost, $owner, $editor);
 
-		$wopi = 'index.php/apps/richdocuments/wopi/files/' . $file->getId() . '_' . $this->settings->getSystemValue('instanceid') . '?access_token=' . $wopiToken;
+		$wopi = 'index.php/apps/richdocuments/wopi/files/' . $file->getId() . '_' . $this->settings->getSystemValue('instanceid') . '?access_token=' . $tokenArray['access_token'];
 		$url = \OC::$server->getURLGenerator()->getAbsoluteURL($wopi);
 
 		return new JSONResponse([ 'Name' => $file->getName(), 'Url' => $url ], Http::STATUS_OK);

--- a/templates/documents.php
+++ b/templates/documents.php
@@ -5,7 +5,8 @@
 	 var rd_permissions = '<?php p($_['permissions']) ?>';
 	 var rd_title = '<?php p($_['title']) ?>';
 	 var rd_fileId = '<?php p($_['fileId']) ?>';
-	 var rd_token = '<?php p($_['token']) ?>';
+	 var rd_access_token = '<?php p($_['access_token']) ?>';
+	 var rd_access_token_ttl = '<?php p($_['access_token_ttl']) ?>';
 	 var rd_urlsrc = '<?php p($_['urlsrc']) ?>';
 	 var rd_path = '<?php p($_['path']) ?>';
 	 var rd_canonical_webroot = '<?php p($_['canonical_webroot']) ?>';

--- a/tests/unit/Db/WopiTest.php
+++ b/tests/unit/Db/WopiTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace OCA\Richdocuments\Db;
+
+use PHPUnit\Framework\TestCase;
+
+class WopiTest extends TestCase {
+	/**
+	 * @var Wopi $wopi
+	 */
+	private $wopi;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->wopi = new Wopi();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+		\OC::$server->getDatabaseConnection()
+			->executeUpdate('DELETE FROM `*PREFIX*richdocuments_wopi`');
+	}
+
+	public function testGenerateToken() {
+		$tokenResult = $this->wopi->generateToken(
+			1,
+			0,
+			7,
+			'ttp://localhost',
+			'user',
+			'user'
+		);
+		$this->assertArrayHasKey('access_token', $tokenResult);
+		$this->assertArrayHasKey('access_token_ttl', $tokenResult);
+	}
+}


### PR DESCRIPTION
Wopi protocol suggests returning access_token_ttl value to wopi client. In this way, wopi client can decide what to do when token about to expire. 
For example, collabora warns user when 15 minutes before expire and shows below message to user:
![resim](https://user-images.githubusercontent.com/14157973/98162431-662bd680-1ef2-11eb-99f4-922d57796b8f.png)

If user still doesn't refresh the session, it warns again periodically in every 2 minutes.

Fixes owncloud/enterprise#4237