### PR TITLE
Fix custom app folder document create problem

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -49,7 +49,8 @@ class Application extends App {
 				$c->query('UserId'),
 				$c->query('ICacheFactory'),
 				$c->query('Logger'),
-				$storage
+				$storage,
+				$c->query('OCP\App\IAppManager')
 			);
 		});
 		$container->registerService('SettingsController', function ($c) {
@@ -141,10 +142,11 @@ class Application extends App {
 
 			if (\class_exists('\OC\Files\Type\TemplateManager')) {
 				$manager = \OC_Helper::getFileTemplateManager();
+				$appPath = \OC::$server->getAppManager()->getAppPath('richdocuments');
 
-				$manager->registerTemplate('application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'apps/richdocuments/assets/docxtemplate.docx');
-				$manager->registerTemplate('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'apps/richdocuments/assets/xlsxtemplate.xlsx');
-				$manager->registerTemplate('application/vnd.openxmlformats-officedocument.presentationml.presentation', 'apps/richdocuments/assets/pptxtemplate.pptx');
+				$manager->registerTemplate('application/vnd.openxmlformats-officedocument.wordprocessingml.document', $appPath . '/assets/docxtemplate.docx');
+				$manager->registerTemplate('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', $appPath . '/assets/xlsxtemplate.xlsx');
+				$manager->registerTemplate('application/vnd.openxmlformats-officedocument.presentationml.presentation', $appPath . '/assets/pptxtemplate.pptx');
 			}
 		}
 

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -13,6 +13,7 @@ namespace OCA\Richdocuments\Controller;
 
 use \OC\Files\View;
 use OCA\Richdocuments\Db\Wopi;
+use OCP\App\IAppManager;
 use \OCP\AppFramework\Controller;
 use \OCP\Constants;
 use OCP\Files\File;
@@ -41,6 +42,7 @@ class DocumentController extends Controller {
 	private $cache;
 	private $logger;
 	private $storage;
+	private $appManager;
 	const ODT_TEMPLATE_PATH = '/assets/odttemplate.odt';
 
 	// Signifies LOOL that document has been changed externally in this storage
@@ -54,7 +56,8 @@ class DocumentController extends Controller {
 								$uid,
 								ICacheFactory $cache,
 								ILogger $logger,
-								Storage $storage) {
+								Storage $storage,
+								IAppManager $appManager) {
 		parent::__construct($appName, $request);
 		$this->uid = $uid;
 		$this->l10n = $l10n;
@@ -63,6 +66,7 @@ class DocumentController extends Controller {
 		$this->cache = $cache->create($appName);
 		$this->logger = $logger;
 		$this->storage = $storage;
+		$this->appManager = $appManager;
 	}
 
 	/**
@@ -443,9 +447,9 @@ class DocumentController extends Controller {
 	 * @NoAdminRequired
 	 */
 	public function create() {
-		$mimetype = $this->request->post['mimetype'];
-		$filename = $this->request->post['filename'];
-		$dir = $this->request->post['dir'];
+		$mimetype = $this->request->getParam('mimetype');
+		$filename = $this->request->getParam('filename');
+		$dir = $this->request->getParam('dir');
 
 		$view = new View('/' . $this->uid . '/files');
 		if (!$dir) {
@@ -488,7 +492,7 @@ class DocumentController extends Controller {
 		}
 
 		if (!$content) {
-			$content = \file_get_contents(\dirname(__DIR__) . self::ODT_TEMPLATE_PATH);
+			$content = \file_get_contents($this->appManager->getAppPath($this->appName) . self::ODT_TEMPLATE_PATH);
 		}
 
 		$discovery_parsed = null;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,5 +5,3 @@ parameters:
   excludes_analyse:
     - %currentWorkingDirectory%/appinfo/Migrations/*.php
     - %currentWorkingDirectory%/appinfo/routes.php
-  ignoreErrors:
-    - '#Access to an undefined property OCP\\IRequest::\$post.#'

--- a/tests/unit/Controller/DocumentControllerTest.php
+++ b/tests/unit/Controller/DocumentControllerTest.php
@@ -11,6 +11,7 @@
 namespace OCA\Richdocuments\Tests\Controller;
 
 use \OCA\Richdocuments\Controller\DocumentController;
+use OCP\App\IAppManager;
 use \OCP\IRequest;
 use \OCP\IConfig;
 use \OCA\Richdocuments\AppConfig;
@@ -18,6 +19,7 @@ use \OCP\IL10N;
 use \OCP\ICacheFactory;
 use \OCP\ILogger;
 use \OCA\Richdocuments\Storage;
+use phpDocumentor\Reflection\Types\This;
 
 /**
  * Class DocumentControllerTest
@@ -54,6 +56,14 @@ class DocumentControllerTest extends \Test\TestCase {
 	 * @var Storage
 	 */
 	private $storage;
+	/**
+	 * @var IAppManager
+	 */
+	private $appMAnager;
+	/**
+	 * @var DocumentController
+	 */
+	private $documentController;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -64,10 +74,8 @@ class DocumentControllerTest extends \Test\TestCase {
 		$this->cache = $this->createMock(ICacheFactory::class);
 		$this->logger = $this->createMock(ILogger::class);
 		$this->storage = $this->createMock(Storage::class);
-	}
-
-	public function testConstructor() {
-		$documentController = new DocumentController(
+		$this->appMAnager = $this->createMock(IAppManager::class);
+		$this->documentController = new DocumentController(
 			'richdocuments',
 			$this->request,
 			$this->settings,
@@ -76,8 +84,12 @@ class DocumentControllerTest extends \Test\TestCase {
 			'test',
 			$this->cache,
 			$this->logger,
-			$this->storage
+			$this->storage,
+			$this->appMAnager
 		);
-		$this->assertInstanceOf(DocumentController::class, $documentController);
+	}
+
+	public function testConstructor() {
+		$this->assertInstanceOf(DocumentController::class, $this->documentController);
 	}
 }


### PR DESCRIPTION
If the richdocuments app is installed in the custom folder and Use OOXML by default for new files option is enabled, richdocuments app could not create any document from template. This pr fixes explained problem.

Fixes https://github.com/owncloud/enterprise/issues/4281