### PR TITLE
in oc10.7 old hooks were removed for master key encryption

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ You can also edit your documents off-line with the Collabora Office app from the
 		<prevent_group_restriction/>
 	</types>
 	<dependencies>
-		<owncloud min-version="10.6" max-version="10" />
+		<owncloud min-version="10.7" max-version="10" />
 	</dependencies>
 	<screenshot>https://owncloud.com/wp-content/uploads/2016/07/code_v2_writer-1-1024x576.png</screenshot>
 	<screenshot>https://owncloud.com/wp-content/uploads/2016/07/code_v2_calc-1-1024x576.png</screenshot>

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -845,7 +845,7 @@ class DocumentController extends Controller {
 		} catch (NotPermittedException $e) {
 			$this->logger->error('wopiCheckFileInfo(): Could not open file - {error}', ['app' => $this->appName, 'error' => $e->getMessage()]);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
-		} catch (Exception $e) {
+		} catch (\Exception $e) {
 			$this->logger->error('wopiCheckFileInfo(): Unexpected Exception - {error}', ['app' => $this->appName, 'error' => $e->getMessage()]);
 			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
@@ -1175,8 +1175,10 @@ class DocumentController extends Controller {
 				// make sure audit/activity is triggered for editor session
 				\OC::$server->getUserSession()->setUser($user);
 
-				// emit login event	to allow decryption of files via master key
+				// emit login event to allow decryption of files via master key
 				$afterEvent = new GenericEvent(null, ['loginType' => 'password', 'user' => $user, 'uid' => $user->getUID(), 'password' => '']);
+
+				/** @phpstan-ignore-next-line */
 				\OC::$server->getEventDispatcher()->dispatch($afterEvent, 'user.afterlogin');
 			} else {
 				// other type of encryption is enabled (e.g. user-key) that does not allow to decrypt files without incognito access to files


### PR DESCRIPTION
In OC10.7 we changed logic for encryption events (got rid of legacy hooks listeners [1][2]). This app needs to be adjusted for this change to trigger decryption of master key files

[1] https://github.com/owncloud/encryption/pull/25
[2] https://github.com/owncloud/core/pull/38289 