### PR TITLE
Allow setting default open action with secure-view enforced session for supported documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ Collabora Online for ownCloud provides collaborating editing functions for text 
 
 See also: https://owncloud.com/collabora/collaborative-editing/
 
+### Configuration
+
+- Set WOPI Server URL
+
+    ```
+    $ occ config:app:set richdocuments wopi_url --value [your-host-public-ip]:8098 
+    ```
+
+- Enable/Disable Secure View and set its settings
+
+    ```
+    $ occ config:app:set richdocuments secure_view_option --value true
+    $ occ config:app:set richdocuments watermark_text --value "Restricted to {viewer-email}" 
+    $ occ config:app:set richdocuments secure_view_open_action_default --value true
+    ```
+
 ### Developing
 
 The easiest way to integrate Collabora with development instance of ownCloud is by disabling SSL for Collabora.
@@ -15,12 +31,13 @@ The easiest way to integrate Collabora with development instance of ownCloud is 
 - Start Collabora Server with default settings
 
     ```
-    $ docker run -t -d -p 9980:9980 -e "extra_params=--o:ssl.enable=false" -e "username=admin" -e "password=admin" --name collabora --cap-add MKNOD collabora/code:4.2.5.3
+    $ docker run -t -d -p 9980:9980 -e "extra_params=--o:ssl.enable=false" -e "username=admin" -e "password=admin" --name collabora --cap-add MKNOD collabora/code:6.4.8.6
     ```
 
 - Access Collabora Admin at `http://[your-host-public-ip]:9980/loleaflet/dist/admin/admin.html` e.g. `172.16.12.95`,
 
 - Set in `Settings -> Admin -> Additional -> Collabora Online server -> http://[your-host-public-ip]:9980`
+
 
 ### Installation
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -120,6 +120,13 @@ var documentsSettings = {
 		);
 	},
 
+	saveSecureViewOpenActionDefault: function(value) {
+		$.post(
+			OC.filePath('richdocuments', 'ajax', 'admin.php'),
+			{ 'secure_view_open_action_default': value }
+		);
+	},
+
 	saveCanPrintDefaultOption: function(value) {
 		$.post(
 			OC.filePath('richdocuments', 'ajax', 'admin.php'),
@@ -338,6 +345,11 @@ var documentsSettings = {
 				var val = $('#secure-view-watermark').val();
 				documentsSettings.saveWatermarkText(val);
 			}
+		});
+
+		$(document).on('change', '#enable_secure_view_open_action_default_cb-richdocuments', function() {
+			var page = $(this).parent();
+			documentsSettings.saveSecureViewOpenActionDefault(this.checked);
 		});
 
 		$(document).on('change', '#secure_view_has_watermark_default_option_cb-richdocuments', function() {

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -45,56 +45,39 @@ var odfViewer = {
 		return (odfViewer.supportedMimes.indexOf(mimetype) !== -1);
 	},
 
-	register : function(){
-		var i,
-		    mime;
+	register : function() {
+		for (var i = 0; i < odfViewer.supportedMimes.length; ++i) {
+			var mime = odfViewer.supportedMimes[i];
 
-		for (i = 0; i < odfViewer.supportedMimes.length; ++i) {
-			mime = odfViewer.supportedMimes[i];
-			OCA.Files.fileActions.registerAction(
-				{
-					name: "Richdocuments",
-					actionHandler: odfViewer.onEdit,
+			if(!$("#isPublic").val() &&
+					OC.appConfig.richdocuments &&
+					OC.appConfig.richdocuments.secureViewAllowed === true &&
+					OC.appConfig.richdocuments.secureViewOpenActionDefault === true) {
+				OCA.Files.fileActions.registerAction({
+					name: 'RichdocumentsSecureView',
+					actionHandler: odfViewer.onOpenWithSecureView,
+					displayName: t('richdocuments', 'Open in Collabora with Secure View'),
+					iconClass: 'icon-lock-closed',
+					permissions: OC.PERMISSION_READ,
+					mime: mime
+				});
+				OCA.Files.fileActions.setDefault(mime, 'RichdocumentsSecureView');
+			} else {
+				OCA.Files.fileActions.registerAction({
+					name: 'Richdocuments',
+					actionHandler: odfViewer.onOpen,
 					displayName: t('richdocuments', 'Open in Collabora'),
 					iconClass: 'icon-rename',
-					permissions: 	OC.PERMISSION_UPDATE | OC.PERMISSION_READ,
+					permissions: OC.PERMISSION_READ,
 					mime: mime
-				}
-			);
-
-			if(OC.appConfig.richdocuments &&
-				OC.appConfig.richdocuments.secureViewAllowed === true &&
-				OC.appConfig.richdocuments.defaultShareAttributes &&
-				OC.appConfig.richdocuments.defaultShareAttributes.secureViewHasWatermark === true
-			){
-				OCA.Files.fileActions.registerAction(
-					{
-						name: "RichdocumentsSecureView",
-						actionHandler: odfViewer.onEditSecureView,
-						displayName: t('richdocuments', 'Open in Collabora with Secure View'),
-						iconClass: 'icon-lock-closed',
-						permissions: OC.PERMISSION_UPDATE | OC.PERMISSION_READ,
-						mime: mime
-					}
-				);
+				});
+				OCA.Files.fileActions.setDefault(mime, 'Richdocuments');
 			}
-
-			OCA.Files.fileActions.setDefault(mime, 'Richdocuments');
 		}
 
 	},
 
-	dispatch : function(filename){
-		if (this.isSupportedMimeType(OCA.Files.fileActions.getCurrentMimeType())
-			&& OCA.Files.fileActions.getCurrentPermissions() & OC.PERMISSION_UPDATE
-		){
-			odfViewer.onEdit(filename);
-		} else {
-			odfViewer.onView(filename);
-		}
-	},
-
-	onEdit : function(fileName, context){
+	onOpen : function(fileName, context){
 		var fileId = context.$file.attr('data-id');
 		var fileDir = context.dir;
 
@@ -116,15 +99,12 @@ var odfViewer = {
 
 	},
 
-	onEditSecureView : function(fileName, context){
+	onOpenWithSecureView : function(fileName, context){
 		var fileId = context.$file.attr('data-id');
 		var fileDir = context.dir;
 
 		var url;
-		if ($("#isPublic").val()) {
-			// Generate url for click on file in public share folder
-			url = OC.generateUrl("apps/richdocuments/public?fileId={file_id}&shareToken={shareToken}&enforceSecureView={enforceSecureView}", { file_id: fileId, shareToken: encodeURIComponent($("#sharingToken").val()), enforceSecureView: "true" });
-		} else if (fileDir) {
+		if (fileDir) {
 			url = OC.generateUrl('apps/richdocuments/index?fileId={file_id}&dir={dir}&enforceSecureView={enforceSecureView}', { file_id: fileId, dir: fileDir, enforceSecureView: "true" });
 		} else {
 			url = OC.generateUrl('apps/richdocuments/index?fileId={file_id}&enforceSecureView={enforceSecureView}', {file_id: fileId, enforceSecureView: "true" });
@@ -135,17 +115,6 @@ var odfViewer = {
 			window.location = url;
 		}
 
-	},
-
-	onView: function(filename, context) {
-	    var attachTo = odfViewer.isDocuments ? '#documents-content' : '#controls';
-
-	    FileList.setViewerMode(true);
-	},
-
-	onClose: function() {
-		FileList.setViewerMode(false);
-		$('#loleafletframe').remove();
 	},
 
 	registerFilesMenu: function(response) {
@@ -228,7 +197,31 @@ var odfViewer = {
 		})(OCA);
 
 		OC.Plugins.register('OCA.Files.NewFileMenu', OCA.FilesLOMenu);
-	}
+	},
+
+	dispatch : function(filename){
+		// FIXME: deprecated?
+		if (this.isSupportedMimeType(OCA.Files.fileActions.getCurrentMimeType())
+			&& OCA.Files.fileActions.getCurrentPermissions() & OC.PERMISSION_UPDATE
+		){
+			odfViewer.onOpen(filename);
+		} else {
+			odfViewer.onView(filename);
+		}
+	},
+
+	onView: function(filename, context) {
+		// FIXME: deprecated?
+	    var attachTo = odfViewer.isDocuments ? '#documents-content' : '#controls';
+
+	    FileList.setViewerMode(true);
+	},
+
+	onClose: function() {
+		// FIXME: deprecated?
+		FileList.setViewerMode(false);
+		$('#loleafletframe').remove();
+	},
 };
 
 $(document).ready(function() {

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -62,7 +62,11 @@ var odfViewer = {
 				}
 			);
 
-			if(OC.appConfig.richdocuments && OC.appConfig.richdocuments.secureViewAllowed === true){
+			if(OC.appConfig.richdocuments &&
+				OC.appConfig.richdocuments.secureViewAllowed === true &&
+				OC.appConfig.richdocuments.defaultShareAttributes &&
+				OC.appConfig.richdocuments.defaultShareAttributes.secureViewHasWatermark === true
+			){
 				OCA.Files.fileActions.registerAction(
 					{
 						name: "RichdocumentsSecureView",

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -62,18 +62,18 @@ var odfViewer = {
 				}
 			);
 
-			//TODO: check by config if active
-			OCA.Files.fileActions.registerAction(
-				{
-					name: "RichdocumentsSecureView",
-					actionHandler: odfViewer.onEditSecureView,
-					displayName: t('richdocuments', 'Open in Collabora with Secure View'),
-					iconClass: 'icon-rename',
-					permissions: OC.PERMISSION_UPDATE | OC.PERMISSION_READ,
-					mime: mime
-				}
-			);
-
+			if(OC.appConfig.richdocuments && OC.appConfig.richdocuments.secureViewAllowed === true){
+				OCA.Files.fileActions.registerAction(
+					{
+						name: "RichdocumentsSecureView",
+						actionHandler: odfViewer.onEditSecureView,
+						displayName: t('richdocuments', 'Open in Collabora with Secure View'),
+						iconClass: 'icon-rename',
+						permissions: OC.PERMISSION_UPDATE | OC.PERMISSION_READ,
+						mime: mime
+					}
+				);
+			}
 
 			OCA.Files.fileActions.setDefault(mime, 'Richdocuments');
 		}

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -72,7 +72,7 @@ var odfViewer = {
 						name: "RichdocumentsSecureView",
 						actionHandler: odfViewer.onEditSecureView,
 						displayName: t('richdocuments', 'Open in Collabora with Secure View'),
-						iconClass: 'icon-rename',
+						iconClass: 'icon-lock-closed',
 						permissions: OC.PERMISSION_UPDATE | OC.PERMISSION_READ,
 						mime: mime
 					}

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -61,6 +61,20 @@ var odfViewer = {
 					mime: mime
 				}
 			);
+
+			//TODO: check by config if active
+			OCA.Files.fileActions.registerAction(
+				{
+					name: "RichdocumentsSecureView",
+					actionHandler: odfViewer.onEditSecureView,
+					displayName: t('richdocuments', 'Open in Collabora with Secure View'),
+					iconClass: 'icon-rename',
+					permissions: OC.PERMISSION_UPDATE | OC.PERMISSION_READ,
+					mime: mime
+				}
+			);
+
+
 			OCA.Files.fileActions.setDefault(mime, 'Richdocuments');
 		}
 
@@ -90,6 +104,28 @@ var odfViewer = {
 			url = OC.generateUrl('apps/richdocuments/index?fileId={file_id}', {file_id: fileId});
 		}
 
+		if (OC.appConfig.richdocuments.openInNewTab === true) {
+			window.open(url,'_blank');
+		} else {
+			window.location = url;
+		}
+
+	},
+
+	onEditSecureView : function(fileName, context){
+		var fileId = context.$file.attr('data-id');
+		var fileDir = context.dir;
+
+		var url;
+		if ($("#isPublic").val()) {
+			// Generate url for click on file in public share folder
+			url = OC.generateUrl("apps/richdocuments/public?fileId={file_id}&shareToken={shareToken}&enforceSecureView={enforceSecureView}", { file_id: fileId, shareToken: encodeURIComponent($("#sharingToken").val()), enforceSecureView: "true" });
+		} else if (fileDir) {
+			url = OC.generateUrl('apps/richdocuments/index?fileId={file_id}&dir={dir}&enforceSecureView={enforceSecureView}', { file_id: fileId, dir: fileDir, enforceSecureView: "true" });
+		} else {
+			url = OC.generateUrl('apps/richdocuments/index?fileId={file_id}&enforceSecureView={enforceSecureView}', {file_id: fileId, enforceSecureView: "true" });
+		}
+		console.log(url);
 		if (OC.appConfig.richdocuments.openInNewTab === true) {
 			window.open(url,'_blank');
 		} else {

--- a/js/viewer/viewer.js
+++ b/js/viewer/viewer.js
@@ -125,7 +125,6 @@ var odfViewer = {
 		} else {
 			url = OC.generateUrl('apps/richdocuments/index?fileId={file_id}&enforceSecureView={enforceSecureView}', {file_id: fileId, enforceSecureView: "true" });
 		}
-		console.log(url);
 		if (OC.appConfig.richdocuments.openInNewTab === true) {
 			window.open(url,'_blank');
 		} else {

--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -21,6 +21,7 @@ class AppConfig {
 	private $appName = 'richdocuments';
 	private $defaults = [
 		'secure_view_option' => 'false',
+		'secure_view_open_action_default' => 'true',
 		'secure_view_can_print_default' => 'false',
 		'secure_view_has_watermark_default' => 'true',
 		'open_in_new_tab' => 'true',

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -176,6 +176,7 @@ class Application extends App {
 				'secureViewCanPrint' => \json_decode($appConfig->getAppValue('secure_view_can_print_default')),
 			],
 			'secureViewAllowed' => \json_decode($appConfig->getAppValue('secure_view_option')),
+			'secureViewOpenActionDefault' => \json_decode($appConfig->getAppValue('secure_view_open_action_default')),
 			'openInNewTab' => \json_decode($appConfig->getAppValue('open_in_new_tab'))
 		];
 	}

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -671,13 +671,14 @@ class DocumentController extends Controller {
 		}
 
 		if ($updatable) {
-			$attributes = $attributes | WOPI::ATTR_CAN_UPDATE;
+			$attributes = $attributes | WOPI::ATTR_CAN_UPDATE & WOPI::ATTR_CAN_UPDATE;
 		}
 
 		$enforceSecureView = \filter_var($this->request->getParam('enforceSecureView', false), FILTER_VALIDATE_BOOLEAN);
 
 		if ($enforceSecureView) {
-			$attributes = WOPI::ATTR_CAN_VIEW | WOPI::ATTR_CAN_EXPORT | WOPI::ATTR_CAN_PRINT | WOPI::ATTR_HAS_WATERMARK;
+			$attributes = $attributes | WOPI::ATTR_HAS_WATERMARK;
+			$attributes &= ~WOPI::ATTR_CAN_UPDATE;
 		}
 
 		$this->logger->debug('getWopiInfoForAuthUser(): File {fileid} is updatable? {updatable}', [

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -674,6 +674,10 @@ class DocumentController extends Controller {
 			$attributes = $attributes | WOPI::ATTR_CAN_UPDATE;
 		}
 
+		if($this->request->getParam('enforceSecureView', false) === 'true'){
+			$attributes = WOPI::ATTR_HAS_WATERMARK;
+		}
+
 		$this->logger->debug('getWopiInfoForAuthUser(): File {fileid} is updatable? {updatable}', [
 			'app' => $this->appName,
 			'fileid' => $fileId,

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -675,7 +675,7 @@ class DocumentController extends Controller {
 		}
 
 		if($this->request->getParam('enforceSecureView', false) === 'true'){
-			$attributes = WOPI::ATTR_HAS_WATERMARK;
+			$attributes = WOPI::ATTR_CAN_VIEW | WOPI::ATTR_CAN_EXPORT | WOPI::ATTR_CAN_PRINT | WOPI::ATTR_HAS_WATERMARK;
 		}
 
 		$this->logger->debug('getWopiInfoForAuthUser(): File {fileid} is updatable? {updatable}', [

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -674,7 +674,9 @@ class DocumentController extends Controller {
 			$attributes = $attributes | WOPI::ATTR_CAN_UPDATE;
 		}
 
-		if($this->request->getParam('enforceSecureView', false) === 'true'){
+		$enforceSecureView = \filter_var($this->request->getParam('enforceSecureView', false), FILTER_VALIDATE_BOOLEAN);
+
+		if ($enforceSecureView) {
 			$attributes = WOPI::ATTR_CAN_VIEW | WOPI::ATTR_CAN_EXPORT | WOPI::ATTR_CAN_PRINT | WOPI::ATTR_HAS_WATERMARK;
 		}
 

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -627,24 +627,40 @@ class DocumentController extends Controller {
 		// default shared session id
 		$sessionid = '0';
 
-		// get file info
+		// get file info and storage
 		$info = $view->getFileInfo($path);
-		/** @var \OCA\Files_Sharing\SharedStorage $storage */
 		$storage = $info->getStorage();
 
-		// check if secure mode feature has been enabled for shares
+		// check if secure mode feature has been enabled for share/file
 		$secureModeEnabled = \OC::$server->getConfig()->getAppValue('richdocuments', 'secure_view_option') === 'true';
-		$isSharedFile = $storage->instanceOfStorage('\OCA\Files_Sharing\SharedStorage');
-		if ($isSharedFile && $secureModeEnabled) {
-			// Extract share attributes
-			/** @var \OCA\Files_Sharing\SharedStorage $storage */
-			$share = $storage->getShare();
-			$canDownload = $share->getAttributes()->getAttribute('permissions', 'download');
-			$viewWithWatermark = $share->getAttributes()->getAttribute('richdocuments', 'view-with-watermark');
-			$canPrint = $share->getAttributes()->getAttribute('richdocuments', 'print');
+		$isSharedFile = $info->getStorage()->instanceOfStorage('\OCA\Files_Sharing\SharedStorage');
+		$enforceSecureView = \filter_var($this->request->getParam('enforceSecureView', false), FILTER_VALIDATE_BOOLEAN);
+		if ($secureModeEnabled) {
+			if ($isSharedFile) {
+				// handle shares
+				/** @var \OCA\Files_Sharing\SharedStorage $storage */
+				$share = $storage->getShare();
+				$canDownload = $share->getAttributes()->getAttribute('permissions', 'download');
+				$viewWithWatermark = $share->getAttributes()->getAttribute('richdocuments', 'view-with-watermark');
+				$canPrint = $share->getAttributes()->getAttribute('richdocuments', 'print');
+				// if view with watermark enforce user-private secure session with dedicated sessionid
+				$sessionid = $viewWithWatermark === true ? $share->getId() : '0';
+			} else {
+				// handle files
+				$canDownload = true;
+				$viewWithWatermark = false;
+				$canPrint = true;
+			}
+			
+			if ($enforceSecureView) {
+				// handle enforced secure view watermark
+				// but preserve other permissions like print/download/edit
+				$viewWithWatermark = true;
+			}
 
 			// restriction on view has been set to false, return forbidden
-			if ($viewWithWatermark === false) {
+			// as there is no supported way of opening this document
+			if ($canDownload === false && $viewWithWatermark === false) {
 				throw new \Exception($this->l10n->t('Insufficient file permissions.'));
 			}
 
@@ -660,10 +676,8 @@ class DocumentController extends Controller {
 				$attributes = $attributes | WOPI::ATTR_CAN_PRINT;
 			}
 
-			// restriction on view with watermarking enabled,
-			// add session-id to force private session with watermark
+			// restriction on view with watermarking enabled
 			if ($viewWithWatermark === true) {
-				$sessionid = $share->getId();
 				$attributes = $attributes | WOPI::ATTR_HAS_WATERMARK;
 			}
 		} else {
@@ -671,14 +685,7 @@ class DocumentController extends Controller {
 		}
 
 		if ($updatable) {
-			$attributes = $attributes | WOPI::ATTR_CAN_UPDATE & WOPI::ATTR_CAN_UPDATE;
-		}
-
-		$enforceSecureView = \filter_var($this->request->getParam('enforceSecureView', false), FILTER_VALIDATE_BOOLEAN);
-
-		if ($enforceSecureView) {
-			$attributes = $attributes | WOPI::ATTR_HAS_WATERMARK;
-			$attributes &= ~WOPI::ATTR_CAN_UPDATE;
+			$attributes = $attributes | WOPI::ATTR_CAN_UPDATE;
 		}
 
 		$this->logger->debug('getWopiInfoForAuthUser(): File {fileid} is updatable? {updatable}', [

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -70,6 +70,7 @@ class SettingsController extends Controller {
 				'masterkey_encryption_enabled' => $this->appConfig->masterEncryptionEnabled() ? 'true' : 'false',
 				'secure_view_allowed' => $this->appConfig->enterpriseFeaturesEnabled() ? 'true' : 'false',
 				'secure_view_option' => $this->appConfig->getAppValue('secure_view_option'),
+				'secure_view_open_action_default' => $this->appConfig->getAppValue('secure_view_open_action_default'),
 				'secure_view_has_watermark_default' => $this->appConfig->getAppValue('secure_view_has_watermark_default'),
 				'secure_view_can_print_default' => $this->appConfig->getAppValue('secure_view_can_print_default'),
 				'watermark_text' => $this->appConfig->getAppValue('watermark_text')
@@ -78,7 +79,7 @@ class SettingsController extends Controller {
 		);
 	}
 
-	public function setSettings($wopi_url, $edit_groups, $doc_format, $test_wopi_url, $test_server_groups, $external_apps, $canonical_webroot, $menu_option, $secure_view_option, $secure_view_can_print_default, $secure_view_has_watermark_default, $watermark_text) {
+	public function setSettings($wopi_url, $edit_groups, $doc_format, $test_wopi_url, $test_server_groups, $external_apps, $canonical_webroot, $menu_option, $secure_view_option, $secure_view_open_action_default, $secure_view_can_print_default, $secure_view_has_watermark_default, $watermark_text) {
 		$message = $this->l10n->t('Saved');
 
 		if ($wopi_url !== null) {
@@ -120,6 +121,10 @@ class SettingsController extends Controller {
 
 		if ($secure_view_option !== null) {
 			$this->appConfig->setAppValue('secure_view_option', $secure_view_option);
+		}
+
+		if ($secure_view_open_action_default !== null) {
+			$this->appConfig->setAppValue('secure_view_open_action_default', $secure_view_open_action_default);
 		}
 
 		if ($secure_view_can_print_default !== null) {

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -83,6 +83,14 @@ script('richdocuments', 'admin');
 } else {
 	p($l->t('Enable Secure View'));
 }?></label>
+	<div id="enable-open-action-with-secure-view-default" style="padding-left: 28px;" class="indent <?php if ($_['secure_view_option'] !== 'true') {
+	p('hidden');
+} ?>" >
+		<p style="max-width: 50em;"><em><?php p($l->t('Settings')) ?></em></p>
+		<input type="checkbox" id="enable_secure_view_open_action_default_cb-richdocuments" <?php p($_['secure_view_open_action_default'] === 'true' ? 'checked' : '') ?> />
+		<label for="enable_secure_view_open_action_default_cb-richdocuments"><?php p($l->t('Open documents in Secure View with watermark by default')) ?></label>
+	</div>
+	<br/>
 	<div id="enable-share-attributes-defaults" style="padding-left: 28px;" class="indent <?php if ($_['secure_view_option'] !== 'true') {
 	p('hidden');
 } ?>" >


### PR DESCRIPTION
Fixes: https://github.com/owncloud/enterprise/issues/4578 , https://github.com/owncloud/enterprise/issues/4566

### Description
With this change, it will be possible to activate the Setting "Open documents in Secure View with watermark by default".
Due to this change, the file owner can view/edit/export/print a file in secure view mode (With watermark) without sharing the file.

![image](https://user-images.githubusercontent.com/26169327/120175315-5f560f80-c206-11eb-8104-333081ef8be2.png)

![image](https://user-images.githubusercontent.com/26169327/120176254-59acf980-c207-11eb-9ed4-df9f19d1b6e2.png)


![image](https://user-images.githubusercontent.com/26169327/120175887-f3c07200-c206-11eb-8795-b20653471e52.png)

![image](https://user-images.githubusercontent.com/26169327/120176067-25d1d400-c207-11eb-8d6d-16fa7e5f0386.png)
