### PR TITLE
Update AppConfig.php

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -21,7 +21,7 @@ class AppConfig {
 	private $appName = 'richdocuments';
 	private $defaults = [
 		'secure_view_option' => 'false',
-		'secure_view_open_action_default' => 'true',
+		'secure_view_open_action_default' => 'false',
 		'secure_view_can_print_default' => 'false',
 		'secure_view_has_watermark_default' => 'true',
 		'open_in_new_tab' => 'true',


### PR DESCRIPTION
related: owncloud/enterprise#4578 , owncloud/enterprise#4566

- [x] disable secure view to be enabled by default for all documents when secure view is enabled


To enable this:
- option 1) in admin setting set checkbox
- option 2) cmd via `occ config:app:set richdocuments secure_view_open_action_default --value true`