### PR TITLE
Enable comments on pdfs 

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -426,7 +426,7 @@ class DocumentController extends Controller {
 
 		// Update permissions
 		$permissions = $doc['permissions'];
-		if (!($doc['action'] === 'edit')) {
+		if (!($doc['action'] === 'edit') && !($doc['action'] === 'view_comment')) {
 			$permissions = $permissions & ~\OCP\Constants::PERMISSION_UPDATE;
 		}
 


### PR DESCRIPTION
Before this PR ist was not possible to add comments on PDF files with rich documents/Collabora, this works now.


Fixes: - https://github.com/owncloud/enterprise/issues/4606


Before:
![image](https://user-images.githubusercontent.com/26169327/121029100-9b5e1700-c7a8-11eb-8e5e-0633516c1492.png)


After:
![image](https://user-images.githubusercontent.com/26169327/121028903-79649480-c7a8-11eb-827c-609953960488.png)