### PR TITLE
Only verify path if filename is given, additional log error

### DIFF
--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -512,13 +512,16 @@ class DocumentController extends Controller {
 			$path = $dir . '/' . $filename;
 		}
 
-		try {
-			$view->verifyPath($path, $filename);
-		} catch (InvalidPathException $e) {
-			return [
-				'status' => 'error',
-				'message' => $this->l10n->t('Invalid filename'),
-			];
+		if ($filename !== null) {
+			try {
+				$view->verifyPath($path, $filename);
+			} catch (InvalidPathException $e) {
+				$this->logger->error('Collabora Online: Encountered error {error}', ['app' => $this->appName, 'error' => $e->getMessage()]);
+				return [
+					'status' => 'error',
+					'message' => $this->l10n->t('Invalid filename'),
+				];
+			}
 		}
 
 		$content = '';


### PR DESCRIPTION
If you create a file via UI Office->New Document, no filename will be set, this will be handled via backend, so we shoud only check the path if filename is given.
Additional add log message on error 'Invalid Path' . 