### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/js/web/richdocuments.js
+++ b/js/web/richdocuments.js
@@ -1915,8 +1915,8 @@ define((function () { 'use strict';
 
               utils.forEach(headers.split('\n'), function parser(line) {
                 i = line.indexOf(':');
-                key = utils.trim(line.substr(0, i)).toLowerCase();
-                val = utils.trim(line.substr(i + 1));
+                key = utils.trim(line.slice(0, i !== -1 ? i : 0)).toLowerCase();
+                val = utils.trim(line.slice(i + 1));
 
                 if (key) {
                   if (parsed[key] && ignoreDuplicateOf.indexOf(key) >= 0) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.