### PR TITLE
Adjust getMimeType for guzzle7 dependencies

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -52,6 +52,7 @@ config = {
             "suites": {
                 "webUISecureView": "webUISecV",
             },
+            "servers": ["daily-master-qa"],
             "browsers": [
                 "chrome",
                 "firefox",

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@ You can also edit your documents off-line with the Collabora Office app from the
 		<prevent_group_restriction/>
 	</types>
 	<dependencies>
-		<owncloud min-version="10.7" max-version="10" />
+		<owncloud min-version="10.11" max-version="10" />
 	</dependencies>
 	<screenshot>https://owncloud.com/wp-content/uploads/2016/07/code_v2_writer-1-1024x576.png</screenshot>
 	<screenshot>https://owncloud.com/wp-content/uploads/2016/07/code_v2_calc-1-1024x576.png</screenshot>

--- a/lib/Controller/WebAssetController.php
+++ b/lib/Controller/WebAssetController.php
@@ -21,7 +21,7 @@
 
 namespace OCA\Richdocuments\Controller;
 
-use GuzzleHttp\Mimetypes;
+use GuzzleHttp\Psr7\MimeType;
 use OC\AppFramework\Http;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataDisplayResponse;
@@ -77,7 +77,6 @@ class WebAssetController extends Controller {
 	}
 
 	private function getMimeType(string $filename): string {
-		$mimeTypes = Mimetypes::getInstance();
-		return $mimeTypes->fromFilename($filename);
+		return MimeType::fromFilename($filename);
 	}
 }


### PR DESCRIPTION
```
$ make test-php-phpstan
composer install
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Generating autoload files
1 package you are using is looking for funding.
Use the `composer fund` command to find out more!
php -d zend.enable_gc=0 vendor-bin/phpstan/vendor/bin/phpstan analyse --memory-limit=4G --configuration=./phpstan.neon --no-progress --level=5 appinfo lib
 ------ ------------------------------------------------------------------------------------ 
  Line   lib/Controller/WebAssetController.php                                               
 ------ ------------------------------------------------------------------------------------ 
  80     Call to static method fromFilename() on an unknown class GuzzleHttp\Psr7\Mimetype.  
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols                  
 ------ ------------------------------------------------------------------------------------ 

 [ERROR] Found 1 error                                                                                                  
                                                                                                                        
make: *** [Makefile:168: test-php-phpstan] Error 1
```

Part of issue https://github.com/owncloud/core/issues/39387