### PR TITLE
[tests-only] [full-ci] Run phan with php 7.3

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -47,6 +47,14 @@ config = {
     ],
     "codestyle": True,
     "phpstan": True,
+    "phan": {
+        "multipleVersions": {
+            "phpVersions": [
+                DEFAULT_PHP_VERSION,
+                "7.3",
+            ],
+        },
+    },
     "javascript": False,
     "phpunit": True,
     "acceptance": {

--- a/.drone.star
+++ b/.drone.star
@@ -370,6 +370,7 @@ def phan(ctx):
 
     default = {
         "phpVersions": [DEFAULT_PHP_VERSION],
+        "extraApps": {},
     }
 
     if "defaults" in config:
@@ -408,6 +409,7 @@ def phan(ctx):
                 },
                 "steps": skipIfUnchanged(ctx, "lint") +
                          installCore(ctx, "daily-master-qa", "sqlite", False) +
+                         installExtraApps(phpVersion, params["extraApps"], False) +
                          [
                              {
                                  "name": "phan",
@@ -1139,6 +1141,7 @@ def acceptance(ctx):
                              testConfig["extraSetup"] +
                              waitForServer(testConfig["federatedServerNeeded"]) +
                              waitForEmailService(testConfig["emailNeeded"]) +
+                             waitForSamba(testConfig["extraServices"]) +
                              fixPermissions(phpVersionForDocker, testConfig["federatedServerNeeded"], params["selUserNeeded"]) +
                              waitForBrowserService(testConfig["browser"]) +
                              [
@@ -1439,6 +1442,26 @@ def waitForEmailService(emailNeeded):
 
     return []
 
+def waitForSamba(extraServices):
+    foundSamba = False
+
+    for extraService in extraServices:
+        # each service entry should be a key-value dictionary that has at least a "name" key
+        # if there is a "samba" service specified, then we need to wait for it to start.
+        if (extraService["name"] == "samba"):
+            foundSamba = True
+
+    if (foundSamba):
+        return [{
+            "name": "wait-for-samba",
+            "image": OC_CI_WAIT_FOR,
+            "commands": [
+                "wait-for -it samba:139,samba:445 -t 300",
+            ],
+        }]
+
+    return []
+
 def ldapService(ldapNeeded):
     if ldapNeeded:
         return [{
@@ -1665,7 +1688,7 @@ def installTestrunner(ctx, phpVersion, useBundledApp):
         ] if not useBundledApp else []),
     }]
 
-def installExtraApps(phpVersion, extraApps):
+def installExtraApps(phpVersion, extraApps, enableExtraApps = True):
     commandArray = []
     for app, command in extraApps.items():
         commandArray.append("ls %s/apps/%s || git clone https://github.com/owncloud/%s.git %s/apps/%s" % (dir["testrunner"], app, app, dir["testrunner"], app))
@@ -1674,9 +1697,10 @@ def installExtraApps(phpVersion, extraApps):
             commandArray.append("cd %s/apps/%s" % (dir["server"], app))
             commandArray.append(command)
         commandArray.append("cd %s" % dir["server"])
-        commandArray.append("php occ a:l")
-        commandArray.append("php occ a:e %s" % app)
-        commandArray.append("php occ a:l")
+        if (enableExtraApps):
+            commandArray.append("php occ a:l")
+            commandArray.append("php occ a:e %s" % app)
+            commandArray.append("php occ a:l")
 
     if (commandArray == []):
         return []

--- a/.phan/config.php
+++ b/.phan/config.php
@@ -38,6 +38,7 @@ return [
         'appinfo',
         'lib',
         'vendor',
+        '../../apps/files/lib',
         '../../lib',
         '../../core'
     ],
@@ -54,6 +55,7 @@ return [
 	//       and `exclude_analysis_directory_list` arrays.
     'exclude_analysis_directory_list' => [
         'vendor',
+        '../../apps/files/lib',
         '../../lib',
         '../../core'
     ],

--- a/appinfo/Migrations/Version20190710194710.php
+++ b/appinfo/Migrations/Version20190710194710.php
@@ -17,6 +17,7 @@ class Version20190710194710 implements ISchemaMigration {
 
 		$fileidColumn = $table->getColumn('fileid');
 		if ($fileidColumn) {
+			/* @phan-suppress-next-line PhanDeprecatedClassConstant */
 			$fileidColumn->setType(Type::getType(Type::BIGINT));
 			$fileidColumn->setOptions(['length' => 20]);
 		}

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -12,6 +12,7 @@
 namespace OCA\Richdocuments;
 
 $application = new \OCA\Richdocuments\AppInfo\Application();
+/* @phan-suppress-next-line PhanUndeclaredThis */
 $application->registerRoutes($this, [
 	'routes' => [
 		//documents

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -13,14 +13,15 @@
 
 namespace OCA\Richdocuments\AppInfo;
 
-use OC_Hook;
 use OCA\Richdocuments\Storage;
 use \OCP\AppFramework\App;
 use \OCA\Richdocuments\Controller\DocumentController;
 use \OCA\Richdocuments\Controller\SettingsController;
 use \OCA\Richdocuments\Controller\WebAssetController;
 use \OCA\Richdocuments\AppConfig;
+/* @phan-suppress-next-line PhanUnreferencedUseNormal */
 use OCP\IContainer;
+/* @phan-suppress-next-line PhanUnreferencedUseNormal */
 use OCP\IUser;
 use OCP\Share;
 use OCP\Util;

--- a/lib/BackgroundJob/CleanupExpiredWopiTokens.php
+++ b/lib/BackgroundJob/CleanupExpiredWopiTokens.php
@@ -53,6 +53,7 @@ class CleanupExpiredWopiTokens extends TimedJob {
 	 */
 	public function run($argument) {
 		$now = $this->timeFactory->getTime();
+		/* @phan-suppress-next-line PhanDeprecatedFunction */
 		$this->connection->executeUpdate(
 			'DELETE FROM `*PREFIX*richdocuments_wopi` WHERE `expiry` <= ?',
 			[$now]

--- a/lib/Controller/DocumentController.php
+++ b/lib/Controller/DocumentController.php
@@ -679,6 +679,7 @@ class DocumentController extends Controller {
 			if ($isSharedFile) {
 				// handle shares
 				/** @var \OCA\Files_Sharing\SharedStorage $storage */
+				/* @phan-suppress-next-line PhanUndeclaredMethod */
 				$share = $storage->getShare();
 				$canDownload = $share->getAttributes()->getAttribute('permissions', 'download');
 				$viewWithWatermark = $share->getAttributes()->getAttribute('richdocuments', 'view-with-watermark');
@@ -746,6 +747,11 @@ class DocumentController extends Controller {
 		$this->updateDocumentEncryptionAccessList($owner, $currentUser, $path);
 
 		$row = new Db\Wopi();
+		/*
+		 * Version is a string here, and arg 2 (version) should be an int.
+		 * As long as the string is just a number, all is good.
+		 */
+		/* @phan-suppress-next-line PhanTypeMismatchArgument */
 		$tokenArray = $row->generateToken($fileId, $version, $attributes, $serverHost, $owner, $currentUser);
 
 		// Return the token.
@@ -821,6 +827,11 @@ class DocumentController extends Controller {
 		}
 
 		$row = new Db\Wopi();
+		/*
+		 * Version is a string here, and arg 2 (version) should be an int.
+		 * As long as the string is just a number, all is good.
+		 */
+		/* @phan-suppress-next-line PhanTypeMismatchArgument */
 		$tokenArray = $row->generateToken($fileId, $version, $attributes, $serverHost, $ownerUid, $currentUser);
 
 		// Return the token.

--- a/lib/Db/Storage.php
+++ b/lib/Db/Storage.php
@@ -12,10 +12,6 @@
 
 namespace OCA\Richdocuments\Db;
 
-/**
- * @method string loadRecentDocumentsForMimes()
- */
-
 class Storage extends \OCA\Richdocuments\Db {
 	public const appName = 'richdocuments';
 
@@ -49,6 +45,11 @@ class Storage extends \OCA\Richdocuments\Db {
 		$files = [];
 		while ($row = $result->fetch()) {
 			$row['mimetype'] = $mimetypeLoader->getMimetypeById($row['mimetype']);
+			/*
+			 * mimepart is a string here, and arg 1 (id) should be an int.
+			 * As long as the string is just a number, all is good.
+			 */
+			/* @phan-suppress-next-line PhanTypeMismatchArgument */
 			$row['mimepart'] = $mimetypeLoader->getMimetypeById($row['mimepart']);
 			$files[] = $row;
 		}

--- a/lib/Http/DownloadResponse.php
+++ b/lib/Http/DownloadResponse.php
@@ -14,7 +14,6 @@ namespace OCA\Richdocuments\Http;
 use \OCP\AppFramework\Http;
 use OCP\Files\File;
 use \OCP\IRequest;
-use \OC\Files\View;
 
 class DownloadResponse extends \OCP\AppFramework\Http\Response {
 	private $request;
@@ -39,6 +38,11 @@ class DownloadResponse extends \OCP\AppFramework\Http\Response {
 		];
 		$size = \strlen($data['content']);
 
+		/*
+		 * Cannot modify read-only magic property \OCP\IRequest->server
+		 * I don't know why phan reports this. The property is not being modified.
+		 */
+		/* @phan-suppress-next-line PhanAccessReadOnlyMagicProperty */
 		if (isset($this->request->server['HTTP_RANGE']) && $this->request->server['HTTP_RANGE'] !== null) {
 			$isValidRange = \preg_match('/^bytes=\d*-\d*(,\d*-\d*)*$/', $this->request->server['HTTP_RANGE']);
 			if (!$isValidRange) {

--- a/lib/Storage.php
+++ b/lib/Storage.php
@@ -218,6 +218,11 @@ class Storage {
 			$mimeType = $rawDocument['mimetype'];
 			$mtime = $rawDocument['mtime'];
 			try {
+				/*
+				 * File id is a string here, and arg 1 should be an int.
+				 * As long as the string is just a number, all is good.
+				 */
+				/* @phan-suppress-next-line PhanTypeMismatchArgument */
 				$path = $view->getPath($fileId);
 			} catch (\Exception $e) {
 				\OC::$server->getLogger()->debug('Path not found for fileId: {fileId}. Skipping', [

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,10 +1,5 @@
 {
-  "config": {
-    "platform": {
-      "php": "7.1"
-    }
-  },
   "require": {
-    "phan/phan": "^5.2"
+    "phan/phan": "^5.4"
   }
 }


### PR DESCRIPTION
`phan` will report errors if any of the code is not compatible with PHP 7.3.

This app still supports PHP 7.3 when used with oC10 core 10.11 and earlier.
