### PR TITLE
Display .documentslist as inline table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -20,7 +20,7 @@
 .documentslist .document,
 .documentslist .progress,
 .documentslist .add-document{
-	display: inline-block;
+	display: inline-table;
 	height: 200px;
 	width: 200px;
 	float: left;


### PR DESCRIPTION
Fixes https://github.com/owncloud/richdocuments/issues/468

Before:

<img width="696" alt="image" src="https://user-images.githubusercontent.com/33026403/224860416-1e4d5042-d5a6-4f08-96d0-01243cb964bd.png">


After:

<img width="696" alt="image" src="https://user-images.githubusercontent.com/33026403/224860335-f267f902-46cd-4d00-807f-7c4488019e03.png">
