### PR TITLE
[tests-only] [full-ci] Remove Symfony event dispatch from ignoreErrors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,6 +12,3 @@ parameters:
     -
       message: '#^Dead catch [^"]* is never thrown in the try block.$#'
       path: lib/Controller/WopiController.php  
-    -
-      message: '#Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required.#'
-      path: lib/FileService.php


### PR DESCRIPTION
Now that core has Symfony5, phpstan no longer complains - good.

Fixes #491 