### PR TITLE
Federated shares support v1 

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -25,7 +25,7 @@ $application->registerRoutes($this, [
 		// Collabora for OC10 legacy frontend
 		['name' => 'document#index', 'url' => 'documents.php/index', 'verb' => 'GET'],
 		["name" => 'document#public', 'url' => 'documents.php/public', "verb" => "GET"],
-		["name" => 'document#remote', 'url' => 'documents.php/remote', "verb" => "GET"],
+		["name" => 'document#federated', 'url' => 'documents.php/federated', "verb" => "GET"],
 		// Collabora for Owncloud Web frontend
 		['name' => 'web_asset#get', 'url' => 'js/richdocuments.js', 'verb' => 'GET'],
 		// WOPI protocol implementation
@@ -35,7 +35,7 @@ $application->registerRoutes($this, [
 		['name' => 'wopi#wopiPutFile', 'url' => 'wopi/files/{documentId}/contents', 'verb' => 'POST'],
 	],
 	'ocs' => [
-		['name' => 'Federation#getWopiUrl', 'url' => '/api/v1/federation', 'verb' => 'GET'],
-		['name' => 'Federation#getRemoteWopiInfo', 'url' => '/api/v1/federation', 'verb' => 'POST'],
+		['name' => 'OCSFederation#index', 'url' => '/api/v1/federation', 'verb' => 'GET'],
+		['name' => 'OCSFederation#getWopiForToken', 'url' => '/api/v1/federation', 'verb' => 'POST'],
 	]
 ]);

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -25,6 +25,7 @@ $application->registerRoutes($this, [
 		// Collabora for OC10 legacy frontend
 		['name' => 'document#index', 'url' => 'documents.php/index', 'verb' => 'GET'],
 		["name" => 'document#public', 'url' => 'documents.php/public', "verb" => "GET"],
+		["name" => 'document#remote', 'url' => 'documents.php/remote', "verb" => "GET"],
 		// Collabora for Owncloud Web frontend
 		['name' => 'web_asset#get', 'url' => 'js/richdocuments.js', 'verb' => 'GET'],
 		// WOPI protocol implementation
@@ -32,5 +33,9 @@ $application->registerRoutes($this, [
 		['name' => 'wopi#wopiFileOperation', 'url' => 'wopi/files/{documentId}', 'verb' => 'POST'],
 		['name' => 'wopi#wopiGetFile', 'url' => 'wopi/files/{documentId}/contents', 'verb' => 'GET'],
 		['name' => 'wopi#wopiPutFile', 'url' => 'wopi/files/{documentId}/contents', 'verb' => 'POST'],
+	],
+	'ocs' => [
+		['name' => 'Federation#getWopiUrl', 'url' => '/api/v1/federation', 'verb' => 'GET'],
+		['name' => 'Federation#getRemoteWopiInfo', 'url' => '/api/v1/federation', 'verb' => 'POST'],
 	]
 ]);

--- a/js/documents.js
+++ b/js/documents.js
@@ -76,7 +76,8 @@ $.widget('oc.documentGrid', {
 	},
 
 	_load : function (fileId){
-		if (fileId){
+		var isRemoteFile = getURLParameter('shareToken');
+		if (fileId || isRemoteFile){
 			documentsMain.initSession();
 			return null;
 		}

--- a/js/documents.js
+++ b/js/documents.js
@@ -655,6 +655,9 @@ var documentsMain = {
 	onStartup: function() {
 		documentsMain.UI.init();
 
+		// TODO: needs invesitigation why comparison operator for null of return
+		// for getURLParamager need to be != 'null', ref. core/js/js.js 
+
 		// Does anything indicate that we need to autostart a session?
 		var fileId = getURLParameter('fileId');
 		if (fileId != 'null')

--- a/js/documents.js
+++ b/js/documents.js
@@ -76,8 +76,8 @@ $.widget('oc.documentGrid', {
 	},
 
 	_load : function (fileId){
-		var isRemoteFile = getURLParameter('shareToken');
-		if (fileId || isRemoteFile){
+		var isShare = getURLParameter('shareToken');
+		if (fileId || isShare) {
 			documentsMain.initSession();
 			return null;
 		}

--- a/js/documents.js
+++ b/js/documents.js
@@ -659,13 +659,22 @@ var documentsMain = {
 		var fileId = getURLParameter('fileId');
 		if (fileId != 'null')
 			documentsMain.fileId = fileId;
+
 		var dir = getURLParameter('dir');
 		if (dir != 'null')
 			documentsMain.returnToDir = dir;
-		var shareToken = getURLParameter('shareToken');
-		if (shareToken != 'null')
-			documentsMain.returnToShare = shareToken;
 
+		var shareToken = getURLParameter('shareToken');
+		if (shareToken != 'null') {
+			// check if local share or federated share
+			var server = getURLParameter('server');
+			if (server != 'null') {
+				documentsMain.returnToServer = server;
+			} else {
+				documentsMain.returnToShare = shareToken;
+			}
+		}
+		
 		// this will launch the document with given fileId
 		documentsMain.show(documentsMain.fileId);
 
@@ -828,6 +837,9 @@ var documentsMain = {
 		if (documentsMain.returnToDir) {
 			documentsMain.overlay.documentOverlay('show');
 			window.location = OC.generateUrl('apps/files?dir={dir}', {dir: documentsMain.returnToDir}, {escape: false});
+		} else if (documentsMain.returnToServer) {
+			documentsMain.overlay.documentOverlay('show');
+			window.location = documentsMain.returnToServer;
 		} else if (documentsMain.returnToShare) {
 			documentsMain.overlay.documentOverlay('show');
 			window.location = OC.generateUrl('s/{shareToken}', {shareToken: documentsMain.returnToShare}, {escape: false});

--- a/lib/Controller/FederationController.php
+++ b/lib/Controller/FederationController.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * ownCloud - Richdocuments App
+ *
+ * @author Szymon Kłos
+ * @copyright 2021 Szymon Kłos szymon.klos@collabora.com
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ */
+
+namespace OCA\Richdocuments\Controller;
+
+use \OCA\Richdocuments\Db\Wopi;
+use \OCP\AppFramework\OCSController;
+use \OCP\AppFramework\Http\DataResponse;
+use \OCP\IConfig;
+use \OCP\IRequest;
+
+class FederationController extends OCSController {
+	private $config;
+
+	public function __construct(
+		string $appName,
+		IRequest $request,
+		IConfig $config
+	) {
+		parent::__construct($appName, $request);
+		$this->config = $config;
+	}
+
+	/**
+	* @PublicPage
+	* @NoCSRFRequired
+	*/
+	public function getWopiUrl() {
+		$data = ['wopi_url' => $this->config->getAppValue('richdocuments', 'wopi_url')];
+		$headers = ['X-Frame-Options' => 'ALLOW'];
+		$response = new DataResponse(['data' => $data], 200, $headers);
+		return $response;
+	}
+
+	/**
+	 * @PublicPage
+	 * @NoCSRFRequired
+	 *
+	 * Wopi info of a remote accessing a file
+	 *
+	 * @param string $token access token provided by remote server
+	 * @return DataResponse
+	 */
+	public function getRemoteWopiInfo($token) {
+		$row = new Wopi();
+		$row->loadBy('token', $token);
+		$wopi = $row->getWopiForToken($token);
+
+		if ($wopi == false) {
+			$code = 404;
+			$data = null;
+		} else {
+			$code = 200;
+			$data = [
+				'editorUid' => $wopi['editor'],
+				'canwrite' => $wopi['attributes'] | Wopi::ATTR_CAN_UPDATE
+			];
+		}
+
+		return new DataResponse(['data' => $data], $code);
+	}
+}

--- a/lib/Controller/OCSFederationController.php
+++ b/lib/Controller/OCSFederationController.php
@@ -12,31 +12,38 @@
 namespace OCA\Richdocuments\Controller;
 
 use \OCA\Richdocuments\Db\Wopi;
+use OCA\Richdocuments\DiscoveryService;
 use \OCP\AppFramework\OCSController;
 use \OCP\AppFramework\Http\DataResponse;
 use \OCP\IConfig;
 use \OCP\IRequest;
 
-class FederationController extends OCSController {
+class OCSFederationController extends OCSController {
 	private $config;
+	private $discoveryService;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		IConfig $config
+		IConfig $config,
+		DiscoveryService $discoveryService
 	) {
 		parent::__construct($appName, $request);
 		$this->config = $config;
+		$this->discoveryService = $discoveryService;
 	}
 
 	/**
 	* @PublicPage
 	* @NoCSRFRequired
 	*/
-	public function getWopiUrl() {
-		$data = ['wopi_url' => $this->config->getAppValue('richdocuments', 'wopi_url')];
+	public function index() {
+		$wopiRemote = $this->discoveryService->getWopiUrl();
+		$data = [
+			'wopi_url' => $wopiRemote
+		];
 		$headers = ['X-Frame-Options' => 'ALLOW'];
-		$response = new DataResponse(['data' => $data], 200, $headers);
+		$response = new DataResponse($data, 200, $headers);
 		return $response;
 	}
 
@@ -49,7 +56,7 @@ class FederationController extends OCSController {
 	 * @param string $token access token provided by remote server
 	 * @return DataResponse
 	 */
-	public function getRemoteWopiInfo($token) {
+	public function getWopiForToken($token) {
 		$row = new Wopi();
 		$row->loadBy('token', $token);
 		$wopi = $row->getWopiForToken($token);

--- a/lib/Controller/OCSFederationController.php
+++ b/lib/Controller/OCSFederationController.php
@@ -24,24 +24,21 @@ namespace OCA\Richdocuments\Controller;
 
 use OCA\Richdocuments\Db\Wopi;
 use OCA\Richdocuments\DiscoveryService;
-use OCA\Richdocuments\FederationService;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\OCSController;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\IRequest;
 
 class OCSFederationController extends OCSController {
 	private $discoveryService;
-	private $federationService;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
-		DiscoveryService $discoveryService,
-		FederationService $federationService
+		DiscoveryService $discoveryService
 	) {
 		parent::__construct($appName, $request);
 		$this->discoveryService = $discoveryService;
-		$this->federationService = $federationService;
 	}
 
 	/**
@@ -54,7 +51,7 @@ class OCSFederationController extends OCSController {
 			'wopi_url' => $wopiRemote
 		];
 		$headers = ['X-Frame-Options' => 'ALLOW'];
-		$response = new DataResponse(['data' => $data], 200, $headers);
+		$response = new DataResponse(['data' => $data], Http::STATUS_OK, $headers);
 		return $response;
 	}
 
@@ -73,14 +70,14 @@ class OCSFederationController extends OCSController {
 		$wopi = $row->getWopiForToken($token);
 
 		if ($wopi == false) {
-			return new DataResponse([], 404);
+			return new DataResponse([], Http::STATUS_NOT_FOUND);
 		}
 
 		return new DataResponse(['data' => [
-			'owner' => $this->federationService->generateFederatedCloudID($wopi['owner']),
-			'editor' => $this->federationService->generateFederatedCloudID($wopi['editor']),
+			'owner' => $wopi['owner'],
+			'editor' => $wopi['editor'],
 			'attributes' => $wopi['attributes'],
 			'server_host' => $wopi['server_host']
-		]], 200);
+		]], Http::STATUS_OK);
 	}
 }

--- a/lib/Controller/OCSFederationController.php
+++ b/lib/Controller/OCSFederationController.php
@@ -1,36 +1,51 @@
 <?php
 /**
- * ownCloud - Richdocuments App
+ * @author Piotr Mrowczynski <piotr@owncloud.com>
+ * @author Szymon Kłos <szymon.klos@collabora.com>
  *
- * @author Szymon Kłos
- * @copyright 2021 Szymon Kłos szymon.klos@collabora.com
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
  *
- * This file is licensed under the Affero General Public License version 3 or
- * later.
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
  */
 
 namespace OCA\Richdocuments\Controller;
 
-use \OCA\Richdocuments\Db\Wopi;
+use OCA\Richdocuments\Db\Wopi;
 use OCA\Richdocuments\DiscoveryService;
-use \OCP\AppFramework\OCSController;
-use \OCP\AppFramework\Http\DataResponse;
-use \OCP\IConfig;
-use \OCP\IRequest;
+use OCP\AppFramework\OCSController;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IURLGenerator;
 
 class OCSFederationController extends OCSController {
 	private $config;
 	private $discoveryService;
+	private $urlGenerator;
 
 	public function __construct(
 		string $appName,
 		IRequest $request,
 		IConfig $config,
-		DiscoveryService $discoveryService
+		DiscoveryService $discoveryService,
+		IURLGenerator $urlGenerator
 	) {
 		parent::__construct($appName, $request);
 		$this->config = $config;
 		$this->discoveryService = $discoveryService;
+		$this->urlGenerator = $urlGenerator;
 	}
 
 	/**
@@ -43,7 +58,7 @@ class OCSFederationController extends OCSController {
 			'wopi_url' => $wopiRemote
 		];
 		$headers = ['X-Frame-Options' => 'ALLOW'];
-		$response = new DataResponse($data, 200, $headers);
+		$response = new DataResponse(['data' => $data], 200, $headers);
 		return $response;
 	}
 
@@ -64,11 +79,68 @@ class OCSFederationController extends OCSController {
 		if ($wopi == false) {
 			return new DataResponse([], 404);
 		} 
-		return new DataResponse([
-			'owner_uid' => $wopi['owner_uid'],
-			'editor_uid' => $wopi['editor_uid'],
+
+		return new DataResponse(['data' => [
+			'owner' => $this->generateFederatedCloudID($wopi['owner']),
+			'editor' => $this->generateFederatedCloudID($wopi['editor']),
 			'attributes' => $wopi['attributes'],
 			'server_host' => $wopi['server_host']
-		], 200);
+		]], 200);
+	}
+
+	/**
+	 * split user and remote from federated cloud id, null if not federated cloud id
+	 *
+	 * @param string $userId user id
+	 * @return string
+	 */
+	public function generateFederatedCloudID(string $userId) : string {
+		if (\strpos($userId, '@') === false) {
+			// generate federated cloud id
+			$user =  $userId;
+			$remote = \preg_replace('|^(.*?://)|', '', \rtrim($this->urlGenerator->getAbsoluteURL('/'), '/'));
+			return "{$user}@{$remote}";
+		}
+
+		// Find the first character that is not allowed in user names
+		$id = \str_replace('\\', '/', $userId);
+		$posSlash = \strpos($id, '/');
+		$posColon = \strpos($id, ':');
+
+		if ($posSlash === false && $posColon === false) {
+			$invalidPos = \strlen($id);
+		} elseif ($posSlash === false) {
+			$invalidPos = $posColon;
+		} elseif ($posColon === false) {
+			$invalidPos = $posSlash;
+		} else {
+			$invalidPos = \min($posSlash, $posColon);
+		}
+
+		// Find the last @ before $invalidPos
+		$pos = $lastAtPos = 0;
+		while ($lastAtPos !== false && $lastAtPos <= $invalidPos) {
+			$pos = $lastAtPos;
+			$lastAtPos = \strpos($id, '@', $pos + 1);
+		}
+
+		if ($pos !== false) {
+			$user = \substr($id, 0, $pos);
+			$remote = \substr($id, $pos + 1);
+			$remote = \str_replace('\\', '/', $remote);
+			if ($fileNamePosition = \strpos($remote, '/index.php')) {
+				$remote = \substr($remote, 0, $fileNamePosition);
+			}
+			$remote = \rtrim($remote, '/');
+			if (!empty($user) && !empty($remote)) {
+				// already a federated cloud id
+				return $userId;
+			}
+		}
+
+		// generate federated cloud id
+		$user =  $userId;
+		$remote = \preg_replace('|^(.*?://)|', '', \rtrim($this->urlGenerator->getAbsoluteURL('/'), '/'));
+		return "{$user}@{$remote}";
 	}
 }

--- a/lib/Controller/OCSFederationController.php
+++ b/lib/Controller/OCSFederationController.php
@@ -62,16 +62,13 @@ class OCSFederationController extends OCSController {
 		$wopi = $row->getWopiForToken($token);
 
 		if ($wopi == false) {
-			$code = 404;
-			$data = null;
-		} else {
-			$code = 200;
-			$data = [
-				'editorUid' => $wopi['editor'],
-				'canwrite' => $wopi['attributes'] | Wopi::ATTR_CAN_UPDATE
-			];
-		}
-
-		return new DataResponse(['data' => $data], $code);
+			return new DataResponse([], 404);
+		} 
+		return new DataResponse([
+			'owner_uid' => $wopi['owner_uid'],
+			'editor_uid' => $wopi['editor_uid'],
+			'attributes' => $wopi['attributes'],
+			'server_host' => $wopi['server_host']
+		], 200);
 	}
 }

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -151,7 +151,9 @@ class WopiController extends Controller {
 		} elseif ($res['editor'] && $res['editor'] !== '' && ($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			// federated share needs to access file as incognito (remote user) as
 			// currently it is not supported to set federated user as file editor
-			// FIXME: knowing federated user we could get its friendly name from DAV contacts
+
+			// FIXME: knowing federated user we could get its friendly name (userFriendlyName) from DAV contacts
+
 			$userId = $res['editor'];
 			$userFriendlyName = $res['editor'];
 			$userEmail = null;

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -21,7 +21,7 @@
 
 namespace OCA\Richdocuments\Controller;
 
-use OC\Security\SecureRandom;
+use OCP\Security\ISecureRandom;
 use OCA\Richdocuments\Db\Wopi;
 use OCP\AppFramework\Controller;
 use OCP\Files\NotPermittedException;
@@ -79,7 +79,7 @@ class WopiController extends Controller {
 	private $userManager;
 
 	/**
-	 * @var SecureRandom
+	 * @var ISecureRandom
 	 */
 	private $secureRandom;
 
@@ -96,7 +96,7 @@ class WopiController extends Controller {
 		FileService $fileService,
 		IURLGenerator $urlGenerator,
 		IUserManager $userManager,
-		SecureRandom $secureRandom
+		ISecureRandom $secureRandom
 	) {
 		parent::__construct($appName, $request);
 		$this->l10n = $l10n;

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -140,7 +140,7 @@ class WopiController extends Controller {
 		$ownerId = $res['owner'];
 
 		// get user info
-		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+		if ($res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			// file editing as local logged in user
 			$editor = $this->userManager->get($res['editor']);
 
@@ -148,7 +148,7 @@ class WopiController extends Controller {
 			$userFriendlyName = $editor->getDisplayName();
 			$userEmail = $editor->getEMailAddress();
 			$isAnonymousUser = false;
-		} elseif ($res['editor'] && $res['editor'] !== '' && ($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+		} elseif ($res['editor'] !== '' && ($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			// federated share needs to access file as incognito (remote user) as
 			// currently it is not supported to set federated user as file editor
 
@@ -194,7 +194,7 @@ class WopiController extends Controller {
 		}
 
 		// cannot write relative when public link or federated access, or when parent folder is not writable
-		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+		if ($res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			$userCanNotWriteRelative = !$file->getParent()->isCreatable();
 		} else {
 			$userCanNotWriteRelative = true;
@@ -222,7 +222,7 @@ class WopiController extends Controller {
 		$result = [
 			'BaseFileName' => $file->getName(),
 			'Size' => $file->getSize(),
-			'Version' => $version,
+			'Version' => \strval($version),
 			'OwnerId' => $ownerId,
 			'UserId' => $userId,
 			'IsAnonymousUser' => $isAnonymousUser,
@@ -304,7 +304,7 @@ class WopiController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+		if ($res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
 		} else {
 			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], null);
@@ -354,7 +354,7 @@ class WopiController extends Controller {
 			'wopiHeaderTime' => $wopiHeaderTime
 		]);
 
-		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+		if ($res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
 		} else {
 			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], null);
@@ -424,7 +424,7 @@ class WopiController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+		if ($res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
 		} else {
 			$this->logger->warning('PutFileRelative: Unexpected call for function for anonymous access', ['app' => $this->appName]);
@@ -438,7 +438,7 @@ class WopiController extends Controller {
 
 		// Retrieve suggested target
 		$suggested = $this->request->getHeader('X-WOPI-SuggestedTarget');
-		$suggested = \iconv('utf-7', 'utf-8', $suggested);
+		$suggested = \iconv('utf-7', 'utf-8', $suggested); // TODO: is really needed?
 
 		if ($suggested[0] === '.') {
 			$path = \dirname($file->getPath()) . '/New File' . $suggested;
@@ -516,7 +516,7 @@ class WopiController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+		if ($res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
 		} else {
 			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], null);
@@ -539,10 +539,10 @@ class WopiController extends Controller {
 		// handle non-existing lock
 		if (empty($locks)) {
 			// get locking user
-			if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+			if ($res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 				$editor = $this->userManager->get($res['editor']);
 				$lockUser = $this->l10n->t('%s via Office Collabora', [$editor->getDisplayName()]);
-			} elseif ($res['editor'] && $res['editor'] !== '' && ($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+			} elseif ($res['editor'] !== '' && ($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 				$lockUser = $this->l10n->t('%s via Office Collabora', [$res['editor']]);
 			} else {
 				$lockUser = $this->l10n->t('Public Link User via Collabora Online');
@@ -613,7 +613,7 @@ class WopiController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+		if ($res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
 		} else {
 			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], null);
@@ -696,7 +696,7 @@ class WopiController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+		if ($res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
 		} else {
 			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], null);
@@ -781,7 +781,7 @@ class WopiController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+		if ($res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
 		} else {
 			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], null);
@@ -828,10 +828,10 @@ class WopiController extends Controller {
 		$this->logger->debug('UnlockAndRelock: unlocking the old lock and locking with new lock.', ['app' => $this->appName]);
 
 		// get re-locking user
-		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+		if ($res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			$editor = $this->userManager->get($res['editor']);
 			$lockUser = $this->l10n->t('%s via Office Collabora', [$editor->getDisplayName()]);
-		} elseif ($res['editor'] && $res['editor'] !== '' && ($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+		} elseif ($res['editor'] !== '' && ($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			$lockUser = $this->l10n->t('%s via Office Collabora', [$res['editor']]);
 		} else {
 			$lockUser = $this->l10n->t('Public Link User via Collabora Online');
@@ -876,7 +876,7 @@ class WopiController extends Controller {
 		}
 
 		// check if the token is for the given file
-		if ($res['fileid'] != $fileId) {
+		if ($res['fileid'] !== $fileId) {
 			$this->logger->debug('Provided wopi token for a wrong file.', ['app' => $this->appName]);
 			return null;
 		}

--- a/lib/Controller/WopiController.php
+++ b/lib/Controller/WopiController.php
@@ -24,7 +24,6 @@ namespace OCA\Richdocuments\Controller;
 use OC\Files\View;
 use OCA\Richdocuments\Db\Wopi;
 use OCP\AppFramework\Controller;
-use OCP\Files\IRootFolder;
 use OCP\Files\InvalidPathException;
 use OCP\Files\NotPermittedException;
 use OCP\Files\Storage\IPersistentLockingStorage;
@@ -71,11 +70,6 @@ class WopiController extends Controller {
 	private $fileService;
 
 	/**
-	 * @var IRootFolder
-	 */
-	private $rootFolder;
-
-	/**
 	 * @var IURLGenerator
 	 */
 	private $urlGenerator;
@@ -96,7 +90,6 @@ class WopiController extends Controller {
 		IL10N $l10n,
 		ILogger $logger,
 		FileService $fileService,
-		IRootFolder $rootFolder,
 		IURLGenerator $urlGenerator,
 		IUserManager $userManager
 	) {
@@ -106,7 +99,6 @@ class WopiController extends Controller {
 		$this->appConfig = $appConfig;
 		$this->logger = $logger;
 		$this->fileService = $fileService;
-		$this->rootFolder = $rootFolder;
 		$this->urlGenerator = $urlGenerator;
 		$this->userManager = $userManager;
 	}
@@ -122,28 +114,61 @@ class WopiController extends Controller {
 	 * and general information about the capabilities that the WOPI host has on the file.
 	 */
 	public function wopiCheckFileInfo(string $documentId): JSONResponse {
-		$token = $this->request->getParam('access_token');
+		$wopiToken = $this->request->getParam('access_token');
 
-		list($fileId, , $version, $sessionId) = Helper::parseDocumentId($documentId);
-		$this->logger->info('CheckFileInfo: Getting info about file {fileId}, version {version} by token {token}.', [
+		$this->logger->debug('CheckFileInfo: documentId {documentId}.', [
 			'app' => $this->appName,
-			'fileId' => $fileId,
-			'version' => $version,
-			'token' => $token ]);
+			'documentId' => $documentId
+		]);
 
-		$row = new Db\Wopi();
-		$row->loadBy('token', $token);
-
-		$res = $row->getWopiForToken($token);
+		$res = $this->getWopiInfoForToken($documentId, $wopiToken);
 		if (!$res) {
 			$this->logger->debug('CheckFileInfo: get token failed.', ['app' => $this->appName]);
-			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		}
+
+		// get origin
+		$postMessageOrigin = $res['server_host'];
+
+		// get owner info
+		$ownerId = $res['owner'];
+
+		// get user info
+		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+			// file editing as local logged in user
+			$editor = $this->userManager->get($res['editor']);
+
+			$userId = $editor->getUID();
+			$userFriendlyName = $editor->getDisplayName();
+			$userEmail = $editor->getEMailAddress();
+			$isAnonymousUser = false;
+		} else if ($res['editor'] && $res['editor'] !== '' && ($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+			// federated share needs to access file as incognito (remote user) as 
+			// currently it is not supported to set federated user as file editor
+			$userId = $res['editor'];
+			$userFriendlyName = $res['editor'];
+			$userEmail = null;
+			$isAnonymousUser = true;
+		} else {
+			// public link needs to access file as incognito (remote user)
+			$userId = 'public-link-user-' . \OC::$server->getSecureRandom()->generate(8);
+			$userFriendlyName = $this->l10n->t('public link user');
+			$userEmail = null;
+			$isAnonymousUser = true;
+		}
+
+		// get file handle
+		$fileId = $res['fileid'];
+		$version = $res['version'];
+		if ($isAnonymousUser) {
+			$file = $this->fileService->getFileHandle($fileId, $ownerId, null);
+		} else {
+			$file = $this->fileService->getFileHandle($fileId, $ownerId, $userId);
 		}
 
 		// make sure file can be read when checking file info
-		$file = $this->fileService->getFileHandle($fileId, $res['owner'], $res['editor']);
 		if (!$file) {
-			$this->logger->error('CheckFileInfo: Could not retrieve file', ['app' => $this->appName]);
+			$this->logger->error('File not found or user unauthorized.', ['app' => $this->appName]);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
@@ -152,34 +177,30 @@ class WopiController extends Controller {
 		try {
 			$file->fopen('rb');
 		} catch (NotPermittedException $e) {
-			$this->logger->error('CheckFileInfo: Could not open file - {error}', ['app' => $this->appName, 'error' => $e->getMessage()]);
+			$this->logger->error('Could not open file - {error}', ['app' => $this->appName, 'error' => $e->getMessage()]);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		} catch (\Exception $e) {
-			$this->logger->error('CheckFileInfo: Unexpected Exception - {error}', ['app' => $this->appName, 'error' => $e->getMessage()]);
+			$this->logger->error('CheckFileInfo: unexpected exception - {error}', ['app' => $this->appName, 'error' => $e->getMessage()]);
 			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 
-		if ($res['editor'] && $res['editor'] !== '') {
-			$editor = $this->userManager->get($res['editor']);
-			$editorId = $editor->getUID();
-			$editorDisplayName = $editor->getDisplayName();
-			$editorEmail = $editor->getEMailAddress();
+		// cannot write relative when public link or federated access, or when parent folder is not writable
+		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
 			$userCanNotWriteRelative = !$file->getParent()->isCreatable();
 		} else {
-			$editorId = $this->l10n->t('remote user');
-			$editorDisplayName = $this->l10n->t('remote user');
-			$editorEmail = null;
 			$userCanNotWriteRelative = true;
 		}
 
+		// check permissions
 		$canWrite = $res['attributes'] & WOPI::ATTR_CAN_UPDATE;
 		$canPrint = $res['attributes'] & WOPI::ATTR_CAN_PRINT;
 		$canExport = $res['attributes'] & WOPI::ATTR_CAN_EXPORT;
 
+		// check watermark text
 		if ($res['attributes'] & WOPI::ATTR_HAS_WATERMARK) {
 			$watermark = \str_replace(
 				'{viewer-email}',
-				$editorEmail === null ? $editorDisplayName : $editorEmail,
+				$userEmail === null ? $userFriendlyName : $userEmail,
 				$this->appConfig->getAppValue('watermark_text')
 			);
 		} else {
@@ -193,14 +214,15 @@ class WopiController extends Controller {
 			'BaseFileName' => $file->getName(),
 			'Size' => $file->getSize(),
 			'Version' => $version,
-			'OwnerId' => $res['owner'],
-			'UserId' => $editorId,
-			'UserFriendlyName' => $editorDisplayName,
+			'OwnerId' => $ownerId,
+			'UserId' => $userId,
+			'IsAnonymousUser' => $isAnonymousUser,
+			'UserFriendlyName' => $userFriendlyName,
 			'UserCanWrite' => $canWrite,
 			'SupportsGetLock' => false,
 			'SupportsLocks' => $supportsLocks,
 			'UserCanNotWriteRelative' => $userCanNotWriteRelative,
-			'PostMessageOrigin' => $res['server_host'],
+			'PostMessageOrigin' => $postMessageOrigin,
 			'LastModifiedTime' => Helper::toISO8601($file->getMTime()),
 			'DisablePrint' => !$canPrint,
 			'HidePrintOption' => !$canPrint,
@@ -212,7 +234,6 @@ class WopiController extends Controller {
 		];
 		
 		$this->logger->debug("CheckFileInfo: Result: {result}", ['app' => $this->appName, 'result' => $result]);
-
 		return new JSONResponse($result, Http::STATUS_OK);
 	}
 
@@ -261,25 +282,25 @@ class WopiController extends Controller {
 	 * The GetFile operation retrieves a file from a host.
 	 */
 	public function wopiGetFile(string $documentId): Response {
-		$token = $this->request->getParam('access_token');
+		$wopiToken = $this->request->getParam('access_token');
 
-		list($fileId, , , ) = Helper::parseDocumentId($documentId);
-		$this->logger->info('GetFile: File {fileId}, token {token}.', [
+		$this->logger->debug('GetFile: documentId {documentId}.', [
 			'app' => $this->appName,
-			'fileId' => $fileId,
-			'token' => $token ]);
+			'documentId' => $documentId
+		]);
 
-		$row = new Db\Wopi();
-		$row->loadBy('token', $token);
-
-		//TODO: Support X-WOPIMaxExpectedSize header.
-		$res = $row->getWopiForToken($token);
+		$res = $this->getWopiInfoForToken($documentId, $wopiToken);
 		if (!$res) {
 			$this->logger->debug('GetFile: get token failed.', ['app' => $this->appName]);
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		$file = $this->fileService->getFileHandle($fileId, $res['owner'], $res['editor']);
+		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
+		} else {
+			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], null);
+		}
+
 		if (!$file) {
 			$this->logger->warning('GetFile: Could not retrieve file', ['app' => $this->appName]);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
@@ -298,19 +319,14 @@ class WopiController extends Controller {
 	 * The PutFile operation updates a file’s binary contents.
 	 */
 	public function wopiPutFile(string $documentId): JSONResponse {
-		$token = $this->request->getParam('access_token');
+		$wopiToken = $this->request->getParam('access_token');
 
-		list($fileId, , , ) = Helper::parseDocumentId($documentId);
-		$this->logger->debug('PutFile: file {fileId}, token {token}.', [
+		$this->logger->debug('PutFile: documentId {documentId}.', [
 			'app' => $this->appName,
-			'fileId' => $fileId,
-			'token' => $token
+			'documentId' => $documentId
 		]);
 
-		$row = new Db\Wopi();
-		$row->loadBy('token', $token);
-
-		$res = $row->getWopiForToken($token);
+		$res = $this->getWopiInfoForToken($documentId, $wopiToken);
 		if (!$res) {
 			$this->logger->debug('PutFile: get token failed.', ['app' => $this->appName]);
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
@@ -329,11 +345,12 @@ class WopiController extends Controller {
 			'wopiHeaderTime' => $wopiHeaderTime
 		]);
 
-		// get owner and editor uid's
-		$owner = $res['owner'];
-		$editor = $res['editor'];
+		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
+		} else {
+			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], null);
+		}
 
-		$file = $this->fileService->getFileHandle($fileId, $owner, $editor);
 		if (!$file) {
 			$this->logger->warning('PutFile: Could not retrieve file', ['app' => $this->appName]);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
@@ -353,16 +370,16 @@ class WopiController extends Controller {
 		}
 
 		// Read the contents of the file from the POST body and store.
-		$content = \fopen('php://input', 'r');
 		$this->logger->debug(
 			'PutFile: storing file {fileId}, editor: {editor}, owner: {owner}.',
 			[
 				'app' => $this->appName,
-				'fileId' => $fileId,
-				'editor' => $editor,
-				'owner' => $owner
+				'fileId' => $res['fileid'],
+				'editor' => $res['editor'],
+				'owner' => $res['owner']
 			]
 		);
+		$content = \fopen('php://input', 'r');
 		$file->putContent($content);
 
 		$this->logger->debug('PutFile: mtime', ['app' => $this->appName]);
@@ -379,18 +396,14 @@ class WopiController extends Controller {
 	 * The Files endpoint operation PutFileRelative.
 	 */
 	public function wopiPutFileRelative(string $documentId): JSONResponse {
-		$token = $this->request->getParam('access_token');
+		$wopiToken = $this->request->getParam('access_token');
 
-		list($fileId, , , ) = Helper::parseDocumentId($documentId);
-		$this->logger->debug('PutFileRelative: file {fileId}, token {token}.', [
+		$this->logger->debug('PutFileRelative: documentId {documentId}.', [
 			'app' => $this->appName,
-			'fileId' => $fileId,
-			'token' => $token]);
+			'documentId' => $documentId
+		]);
 
-		$row = new Db\Wopi();
-		$row->loadBy('token', $token);
-
-		$res = $row->getWopiForToken($token);
+		$res = $this->getWopiInfoForToken($documentId, $wopiToken);
 		if (!$res) {
 			$this->logger->debug('PutFileRelative: get token failed.', ['app' => $this->appName]);
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
@@ -402,20 +415,21 @@ class WopiController extends Controller {
 			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		// get owner and editor uid's
-		$owner = $res['owner'];
-		$editor = $res['editor'];
+		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
+		} else {
+			$this->logger->warning('PutFileRelative: Unexpected call for function for anonymous access', ['app' => $this->appName]);
+			return new JSONResponse([], Http::STATUS_INTERNAL_SERVER_ERROR);
+		}
+
+		if (!$file) {
+			$this->logger->warning('PutFileRelative: Could not retrieve file', ['app' => $this->appName]);
+			return new JSONResponse([], Http::STATUS_NOT_FOUND);
+		}
 
 		// Retrieve suggested target
 		$suggested = $this->request->getHeader('X-WOPI-SuggestedTarget');
 		$suggested = \iconv('utf-7', 'utf-8', $suggested);
-		
-		$file = $this->fileService->getFileHandle($fileId, $owner, $editor);
-
-		if (!$file) {
-			$this->logger->warning('PutFileRelative: could not retrieve file', ['app' => $this->appName]);
-			return new JSONResponse([], Http::STATUS_NOT_FOUND);
-		}
 
 		$path = '';
 		if ($suggested[0] === '.') {
@@ -423,7 +437,8 @@ class WopiController extends Controller {
 		} elseif ($suggested[0] !== '/') {
 			$path = \dirname($file->getPath()) . '/' . $suggested;
 		} else {
-			$path = $this->rootFolder->getUserFolder($editor)->getPath() . $suggested;
+			$this->logger->debug('PutFileRelative: Suggested path {suggested} not supported', ['app' => $this->appName, 'suggested' => $suggested]);
+			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
 		}
 
 		if ($path === '') {
@@ -433,43 +448,26 @@ class WopiController extends Controller {
 			], Http::STATUS_BAD_REQUEST);
 		}
 
-		// create the folder first
-		if (!$this->rootFolder->nodeExists(\dirname($path))) {
-			$this->rootFolder->newFolder(\dirname($path));
-		}
-
-		try {
-			$view = new View('/' . $editor . '/files');
-			$view->verifyPath($path, $suggested);
-		} catch (InvalidPathException $e) {
-			return new JSONResponse([
-				'status' => 'error',
-				'message' => $this->l10n->t('Invalid filename'),
-			], Http::STATUS_BAD_REQUEST);
-		}
-
 		// create a unique new file
-		$path = $this->rootFolder->getNonExistingName($path);
-		$file = $this->rootFolder->newFile($path);
-		$file = $this->fileService->getFileHandle($file->getId(), $owner, $editor);
-		if (!$file) {
-			$this->logger->warning('PutFileRelative: could not retrieve file', ['app' => $this->appName]);
+		$newFile = $this->fileService->newFile($path, $res['owner'], $res['editor']);
+		if (!$newFile) {
+			$this->logger->warning('PutFileRelative: could not create new file', ['app' => $this->appName]);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
 		// Read the contents of the file from the POST body and store.
 		$content = \fopen('php://input', 'r');
 
-		$file->putContent($content);
-		$mtime = $file->getMtime();
+		$newFile->putContent($content);
+		$mtime = $newFile->getMtime();
 
 		$this->logger->debug(
 			'PutFileRelative: storing file {fileId}, editor: {editor}, owner: {owner}, mtime: {mtime}.',
 			[
 			'app' => $this->appName,
-			'fileId' => $fileId,
-			'editor' => $editor,
-			'owner' => $owner,
+			'fileId' => $newFile->getId(),
+			'editor' => $res['editor'],
+			'owner' => $res['owner'],
 			'mtime' => $mtime
 			]
 		);
@@ -481,47 +479,50 @@ class WopiController extends Controller {
 
 		// Continue editing
 		$attributes = WOPI::ATTR_CAN_VIEW | WOPI::ATTR_CAN_UPDATE | WOPI::ATTR_CAN_PRINT;
-		// generate a token for the new file
-		$tokenArray = $row->generateToken($file->getId(), 0, $attributes, $serverHost, $owner, $editor);
 
-		$wopi = 'index.php/apps/richdocuments/wopi/files/' . $file->getId() . '_' . $this->settings->getSystemValue('instanceid') . '?access_token=' . $tokenArray['access_token'];
+		// generate a token for the new file
+		$row = new Db\Wopi();
+		$tokenArray = $row->generateToken($newFile->getId(), 0, $attributes, $serverHost, $res['owner'], $res['editor']);
+
+		$wopi = 'index.php/apps/richdocuments/wopi/files/' . $newFile->getId() . '_' . $this->settings->getSystemValue('instanceid') . '?access_token=' . $tokenArray['access_token'];
 		$url = $this->urlGenerator->getAbsoluteURL($wopi);
 
-		return new JSONResponse([ 'Name' => $file->getName(), 'Url' => $url ], Http::STATUS_OK);
+		return new JSONResponse([ 'Name' => $newFile->getName(), 'Url' => $url ], Http::STATUS_OK);
 	}
 
 	/**
 	 * The Files endpoint operation Lock.
 	 */
 	public function wopiLock(string $documentId): JSONResponse {
-		$token = $this->request->getParam('access_token');
-
-		// get wopi lock token
+		$wopiToken = $this->request->getParam('access_token');
 		$wopiLock = $this->request->getHeader('X-WOPI-Lock');
 
-		list($fileId, , , ) = Helper::parseDocumentId($documentId);
-		$this->logger->debug('Lock: file {fileId}, wopiLock {wopiLock}, token {token}.', [
+		$this->logger->debug('Lock: documentId {documentId}, wopiLock {wopiLock}.', [
 			'app' => $this->appName,
-			'fileId' => $fileId,
+			'documentId' => $documentId,
 			'wopiLock' => $wopiLock,
-			'token' => $token]);
+		]);
 
-		$row = new Db\Wopi();
-		$row->loadBy('token', $token);
-		$res = $row->getWopiForToken($token);
+		$res = $this->getWopiInfoForToken($documentId, $wopiToken);
 		if (!$res) {
 			$this->logger->debug('Lock: get token failed.', ['app' => $this->appName]);
-			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		// get owner and editor uid's
-		$owner = $res['owner'];
-		$editor = $res['editor'];
-		
-		$file = $this->fileService->getFileHandle($fileId, $owner, $editor);
+		$canWrite = $res['attributes'] & WOPI::ATTR_CAN_UPDATE;
+		if (!$canWrite) {
+			$this->logger->debug('Lock: not allowed.', ['app' => $this->appName]);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		}
+
+		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
+		} else {
+			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], null);
+		}
 
 		if (!$file) {
-			$this->logger->warning('Lock: could not retrieve file', ['app' => $this->appName]);
+			$this->logger->warning('Lock: Could not retrieve file', ['app' => $this->appName]);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
@@ -535,35 +536,27 @@ class WopiController extends Controller {
 		$locks = $storage->getLocks($file->getInternalPath(), false);
 
 		// handle non-existing lock
-
 		if (empty($locks)) {
-			// set new lock
-			if (isset($editor) && $editor !== '') {
-				$this->logger->debug('Lock: locking the file for user.', ['app' => $this->appName]);
-				$user = $this->userManager->get($editor);
-
-				/**
-				 * @var IPersistentLockingStorage $storage
-				 * @phpstan-ignore-next-line
-				*/
-				'@phan-var IPersistentLockingStorage $storage';
-				$storage->lockNodePersistent($file->getInternalPath(), [
-					'token' => $wopiLock,
-					'owner' => $this->l10n->t('%s via Office Collabora', [$user->getDisplayName()])
-				]);
+			// get locking user
+			if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+				$editor = $this->userManager->get($res['editor']);
+				$lockUser = $this->l10n->t('%s via Office Collabora', [$editor->getDisplayName()]);
+			} else if ($res['editor'] && $res['editor'] !== '' && ($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+				$lockUser = $this->l10n->t('%s via Office Collabora', [$res['editor']]);
 			} else {
-				$this->logger->debug('Lock: locking the file for public link.', ['app' => $this->appName]);
-
-				/**
-				 * @var IPersistentLockingStorage $storage
-				 * @phpstan-ignore-next-line
-				*/
-				'@phan-var IPersistentLockingStorage $storage';
-				$storage->lockNodePersistent($file->getInternalPath(), [
-					'token' => $wopiLock,
-					'owner' => $this->l10n->t('Public Link User via Collabora Online')
-				]);
+				$lockUser = $this->l10n->t('Public Link User via Collabora Online');
 			}
+
+			// set new lock
+			/**
+			 * @var IPersistentLockingStorage $storage
+		     * @phpstan-ignore-next-line
+		     */
+			'@phan-var IPersistentLockingStorage $storage';
+			$storage->lockNodePersistent($file->getInternalPath(), [
+				'token' => $wopiLock,
+				'owner' => $lockUser
+			]);
 			return new JSONResponse([], Http::STATUS_OK);
 		}
 
@@ -598,34 +591,35 @@ class WopiController extends Controller {
 	 * The Files endpoint operation Unlock.
 	 */
 	public function wopiUnlock(string $documentId): JSONResponse {
-		$token = $this->request->getParam('access_token');
-
-		// get wopi lock token
+		$wopiToken = $this->request->getParam('access_token');
 		$wopiLock = $this->request->getHeader('X-WOPI-Lock');
 
-		list($fileId, , , ) = Helper::parseDocumentId($documentId);
-		$this->logger->debug('Unlock: file {fileId}, wopiLock {wopiLock}, token {token}.', [
+		$this->logger->debug('Unlock: documentId {documentId}, wopiLock {wopiLock}.', [
 			'app' => $this->appName,
-			'fileId' => $fileId,
+			'documentId' => $documentId,
 			'wopiLock' => $wopiLock,
-			'token' => $token]);
+		]);
 
-		$row = new Db\Wopi();
-		$row->loadBy('token', $token);
-		$res = $row->getWopiForToken($token);
+		$res = $this->getWopiInfoForToken($documentId, $wopiToken);
 		if (!$res) {
 			$this->logger->debug('Unlock: get token failed.', ['app' => $this->appName]);
-			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		// get owner and editor uid's
-		$owner = $res['owner'];
-		$editor = $res['editor'];
-		
-		$file = $this->fileService->getFileHandle($fileId, $owner, $editor);
+		$canWrite = $res['attributes'] & WOPI::ATTR_CAN_UPDATE;
+		if (!$canWrite) {
+			$this->logger->debug('Unlock: not allowed.', ['app' => $this->appName]);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		}
+
+		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
+		} else {
+			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], null);
+		}
 
 		if (!$file) {
-			$this->logger->warning('Unlock: could not retrieve file', ['app' => $this->appName]);
+			$this->logger->warning('Unlock: Could not retrieve file', ['app' => $this->appName]);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
@@ -680,34 +674,35 @@ class WopiController extends Controller {
 	 * The Files endpoint operation RefreshLock.
 	 */
 	public function wopiRefreshLock(string $documentId): JSONResponse {
-		$token = $this->request->getParam('access_token');
-
-		// get wopi lock token
+		$wopiToken = $this->request->getParam('access_token');
 		$wopiLock = $this->request->getHeader('X-WOPI-Lock');
 
-		list($fileId, , , ) = Helper::parseDocumentId($documentId);
-		$this->logger->debug('RefreshLock: file {fileId}, wopiLock {wopiLock}, token {token}.', [
+		$this->logger->debug('RefreshLock: documentId {documentId}, wopiLock {wopiLock}.', [
 			'app' => $this->appName,
-			'fileId' => $fileId,
+			'documentId' => $documentId,
 			'wopiLock' => $wopiLock,
-			'token' => $token]);
+		]);
 
-		$row = new Db\Wopi();
-		$row->loadBy('token', $token);
-		$res = $row->getWopiForToken($token);
+		$res = $this->getWopiInfoForToken($documentId, $wopiToken);
 		if (!$res) {
 			$this->logger->debug('RefreshLock: get token failed.', ['app' => $this->appName]);
-			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		// get owner and editor uid's
-		$owner = $res['owner'];
-		$editor = $res['editor'];
-		
-		$file = $this->fileService->getFileHandle($fileId, $owner, $editor);
+		$canWrite = $res['attributes'] & WOPI::ATTR_CAN_UPDATE;
+		if (!$canWrite) {
+			$this->logger->debug('RefreshLock: not allowed.', ['app' => $this->appName]);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		}
+
+		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
+		} else {
+			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], null);
+		}
 
 		if (!$file) {
-			$this->logger->warning('RefreshLock: could not retrieve file', ['app' => $this->appName]);
+			$this->logger->warning('Unlock: Could not retrieve file', ['app' => $this->appName]);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
@@ -762,36 +757,37 @@ class WopiController extends Controller {
 	 * The Files endpoint operation UnlockAndRelock.
 	 */
 	public function wopiUnlockAndRelock(string $documentId): JSONResponse {
-		$token = $this->request->getParam('access_token');
-
-		// get wopi lock token
+		$wopiToken = $this->request->getParam('access_token');
 		$wopiLock = $this->request->getHeader('X-WOPI-Lock');
 		$wopiLockOld = $this->request->getHeader('X-WOPI-OldLock');
 
-		list($fileId, , , ) = Helper::parseDocumentId($documentId);
-		$this->logger->debug('UnlockAndRelock: file {fileId}, wopiLock {wopiLock}, wopiLockOld {wopiLockOld}, token {token}.', [
+		$this->logger->debug('Unlock: documentId {documentId}, wopiLock {wopiLock}, wopiLockOld {wopiLockOld}.', [
 			'app' => $this->appName,
-			'fileId' => $fileId,
+			'documentId' => $documentId,
 			'wopiLock' => $wopiLock,
 			'wopiLockOld' => $wopiLockOld,
-			'token' => $token]);
+		]);
 
-		$row = new Db\Wopi();
-		$row->loadBy('token', $token);
-		$res = $row->getWopiForToken($token);
+		$res = $this->getWopiInfoForToken($documentId, $wopiToken);
 		if (!$res) {
-			$this->logger->debug('UnlockAndRelock: get token failed.', ['app' => $this->appName]);
-			return new JSONResponse([], Http::STATUS_UNAUTHORIZED);
+			$this->logger->debug('Unlock: get token failed.', ['app' => $this->appName]);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
 		}
 
-		// get owner and editor uid's
-		$owner = $res['owner'];
-		$editor = $res['editor'];
-		
-		$file = $this->fileService->getFileHandle($fileId, $owner, $editor);
+		$canWrite = $res['attributes'] & WOPI::ATTR_CAN_UPDATE;
+		if (!$canWrite) {
+			$this->logger->debug('Unlock: not allowed.', ['app' => $this->appName]);
+			return new JSONResponse([], Http::STATUS_FORBIDDEN);
+		}
+
+		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], $res['editor']);
+		} else {
+			$file = $this->fileService->getFileHandle($res['fileid'], $res['owner'], null);
+		}
 
 		if (!$file) {
-			$this->logger->warning('UnlockAndRelock: could not retrieve file', ['app' => $this->appName]);
+			$this->logger->warning('Unlock: Could not retrieve file', ['app' => $this->appName]);
 			return new JSONResponse([], Http::STATUS_NOT_FOUND);
 		}
 
@@ -830,6 +826,16 @@ class WopiController extends Controller {
 
 		$this->logger->debug('UnlockAndRelock: unlocking the old lock and locking with new lock.', ['app' => $this->appName]);
 
+		// get re-locking user
+		if ($res['editor'] && $res['editor'] !== '' && !($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+			$editor = $this->userManager->get($res['editor']);
+			$lockUser = $this->l10n->t('%s via Office Collabora', [$editor->getDisplayName()]);
+		} else if ($res['editor'] && $res['editor'] !== '' && ($res['attributes'] & WOPI::ATTR_FEDERATED)) {
+			$lockUser = $this->l10n->t('%s via Office Collabora', [$res['editor']]);
+		} else {
+			$lockUser = $this->l10n->t('Public Link User via Collabora Online');
+		}
+
 		/**
 		 * @var IPersistentLockingStorage $storage
 		 * @phpstan-ignore-next-line
@@ -839,32 +845,41 @@ class WopiController extends Controller {
 			'token' => $wopiLockOld,
 		]);
 
-		if (isset($editor) && $editor !== '') {
-			$this->logger->debug('UnlockAndRelock: locking the file for user.', ['app' => $this->appName]);
-			$user = $this->userManager->get($editor);
-
-			/**
-			 * @var IPersistentLockingStorage $storage
-			 * @phpstan-ignore-next-line
-			*/
-			'@phan-var IPersistentLockingStorage $storage';
-			$storage->lockNodePersistent($file->getInternalPath(), [
-				'token' => $wopiLock,
-				'owner' => $this->l10n->t('%s via Office Collabora', [$user->getDisplayName()])
-			]);
-		} else {
-			$this->logger->debug('UnlockAndRelock: locking the file for public link.', ['app' => $this->appName]);
-
-			/**
-			 * @var IPersistentLockingStorage $storage
-			 * @phpstan-ignore-next-line
-			*/
-			'@phan-var IPersistentLockingStorage $storage';
-			$storage->lockNodePersistent($file->getInternalPath(), [
-				'token' => $wopiLock,
-				'owner' => $this->l10n->t('Public Link User via Collabora Online')
-			]);
-		}
+		/**
+		 * @var IPersistentLockingStorage $storage
+		 * @phpstan-ignore-next-line
+		 */
+		'@phan-var IPersistentLockingStorage $storage';
+		$storage->lockNodePersistent($file->getInternalPath(), [
+			'token' => $wopiLock,
+			'owner' => $lockUser
+		]);
 		return new JSONResponse([], Http::STATUS_OK);
+	}
+
+	private function getWopiInfoForToken(string $documentId, $wopiToken): ?array {
+		$token = $this->request->getParam('access_token');
+
+		list($fileId, , $version, $sessionId) = Helper::parseDocumentId($documentId);
+		$this->logger->debug('Getting wopi token {token} info for file {fileId}, version {version},', [
+			'app' => $this->appName,
+			'fileId' => $fileId,
+			'version' => $version,
+			'token' => $token ]);
+
+		$row = new Db\Wopi();
+		$res = $row->getWopiForToken($wopiToken);
+		if (!$res) {
+			$this->logger->debug('Cannot find token.', ['app' => $this->appName]);
+			return null;
+		}
+
+		// check if the token is for the given file
+		if ($res['fileid'] != $fileId) {
+			$this->logger->debug('Provided wopi token for a wrong file.', ['app' => $this->appName]);
+			return null;
+		}
+
+		return $res;
 	}
 }

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -21,6 +21,7 @@ class Wopi extends \OCA\Richdocuments\Db {
 	public const ATTR_CAN_EXPORT = 2;
 	public const ATTR_CAN_PRINT = 4;
 	public const ATTR_HAS_WATERMARK = 8;
+	public const ATTR_FEDERATED = 16;
 
 	public const appName = 'richdocuments';
 
@@ -97,6 +98,8 @@ class Wopi extends \OCA\Richdocuments\Db {
 		}
 
 		return [
+			'fileId' => $row['fileId'],
+			'version' => $row['version'],
 			'owner' => $row['owner_uid'],
 			'editor' => $row['editor_uid'],
 			'attributes' => $row['attributes'],

--- a/lib/Db/Wopi.php
+++ b/lib/Db/Wopi.php
@@ -98,7 +98,7 @@ class Wopi extends \OCA\Richdocuments\Db {
 		}
 
 		return [
-			'fileId' => $row['fileId'],
+			'fileid' => $row['fileid'],
 			'version' => $row['version'],
 			'owner' => $row['owner_uid'],
 			'editor' => $row['editor_uid'],

--- a/lib/DocumentService.php
+++ b/lib/DocumentService.php
@@ -214,7 +214,7 @@ class DocumentService {
 
 				// get the federated share token
 				/* @phan-suppress-next-line PhanUndeclaredMethod */
-				$ret['federatedToken'] = $storage->getToken();
+				$ret['federatedShareToken'] = $storage->getToken();
 
 				// get the path of the file in the federates share:
 				//  - in case of shared folder it would be relative path to file in that shared folder
@@ -302,7 +302,6 @@ class DocumentService {
 			return $this->reportError($e->getMessage());
 		}
 	}
-
 
 	/**
 	 * Retrieve document info for the federated share token. If file in the public link folder is used,

--- a/lib/DocumentService.php
+++ b/lib/DocumentService.php
@@ -178,7 +178,7 @@ class DocumentService {
 			$ret['path'] = $root->getRelativePath($document->getPath());
 			$ret['name'] = $document->getName();
 			$ret['fileid'] = $fileId;
-			$ret['version'] = '0'; // latest
+			$ret['version'] = 0; // original file
 
 			if ($isSharedFile && $isSecureModeEnabled) {
 				/** @var \OCA\Files_Sharing\SharedStorage $storage */
@@ -263,7 +263,7 @@ class DocumentService {
 			}
 
 			$node = $share->getNode();
-			if ($node->getType() == FileInfo::TYPE_FILE) {
+			if ($node->getType() === FileInfo::TYPE_FILE) {
 				/** @var \OCP\Files\File|null $node */
 				$document = $node;
 			} elseif ($fileId !== null) {
@@ -292,7 +292,7 @@ class DocumentService {
 			$ret['path'] = $root->getRelativePath($document->getPath());
 			$ret['name'] = $document->getName();
 			$ret['fileid'] = $document->getId();
-			$ret['version'] = '0'; // latest
+			$ret['version'] = 0; // original file
 
 			return $ret;
 		} catch (ShareNotFound $e) {
@@ -323,7 +323,7 @@ class DocumentService {
 			}
 
 			$node = $share->getNode();
-			if ($node->getType() == FileInfo::TYPE_FILE) {
+			if ($node->getType() === FileInfo::TYPE_FILE) {
 				/** @var \OCP\Files\File|null $node */
 				$document = $node;
 			} elseif ($path !== null) {
@@ -352,7 +352,7 @@ class DocumentService {
 			$ret['path'] = $root->getRelativePath($document->getPath());
 			$ret['name'] = $document->getName();
 			$ret['fileid'] = $document->getId();
-			$ret['version'] = '0'; // latest
+			$ret['version'] = 0; // original file
 
 			return $ret;
 		} catch (ShareNotFound $e) {

--- a/lib/DocumentService.php
+++ b/lib/DocumentService.php
@@ -220,7 +220,7 @@ class DocumentService {
 				//  - in case of shared folder it would be relative path to file in that shared folder
 				//  - in case of shared file it would be name of the shared file
 				/* @phan-suppress-next-line PhanUndeclaredMethod */
-				$ret['federatedPath'] = $document->getInternalPath();
+				$ret['federatedShareRelativePath'] = $document->getInternalPath();
 			}
 
 			return $ret;

--- a/lib/DocumentService.php
+++ b/lib/DocumentService.php
@@ -172,7 +172,8 @@ class DocumentService {
 			$ret['secureView'] = false;
 			$ret['secureViewId'] = null;
 			$ret['federatedServer'] = null;
-			$ret['federatedToken'] = null;
+			$ret['federatedShareToken'] = null;
+			$ret['federatedShareRelativePath'] = null;
 			$ret['mimetype'] = $document->getMimeType();
 			$ret['path'] = $root->getRelativePath($document->getPath());
 			$ret['name'] = $document->getName();

--- a/lib/FederationService.php
+++ b/lib/FederationService.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * @author Piotr Mrowczynski <piotr@owncloud.com>
+ *
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Richdocuments;
+
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\ILogger;
+use OCP\Http\Client\IClientService;
+use OCA\Richdocuments\AppConfig;
+use OCP\IURLGenerator;
+use SimpleXMLElement;
+
+class FederationService {
+	/**
+	 * @var AppConfig
+	 */
+	private $appConfig;
+
+	/**
+	 * @var ILogger
+	 */
+	private $logger;
+
+	/**
+	 * @var ICache
+	 */
+	private $cache;
+
+	/**
+	 * @var IURLGenerator
+	 */
+	private $urlGenerator;
+
+	/**
+	 * @var IClientService
+	 */
+	private $httpClient;
+
+	public function __construct(
+		AppConfig $config,
+		ILogger $logger,
+		ICacheFactory $cacheFactory,
+		IURLGenerator $urlGenerator,
+		IClientService $httpClient
+	) {
+		$this->appConfig = $config;
+		$this->logger = $logger;
+		$this->cache = $cacheFactory->create('oca.richdocuments.federation');
+		$this->urlGenerator = $urlGenerator;
+		$this->httpClient = $httpClient;
+	}
+
+	/**
+	 * Get the Url of the collabora document on a federated server.
+	 *
+	 * @param string $shareToken
+	 * @param string $path
+	 * @param string $server
+	 * @param string $accessToken
+	 * @return string with the Url to the given resource
+	 */
+	public function getRemoteFileUrl(string $shareToken, string $path, string $server, string $accessToken) : string {
+		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
+		$remoteFileUrl = \rtrim($server, '/') . '/index.php/apps/richdocuments/documents.php/federated' .
+			'?shareToken=' . $shareToken .
+			'&path=' . $path .
+			'&server=' . \rtrim($serverHost, '/') .
+			'&accessToken=' . $accessToken;
+		return $remoteFileUrl;
+	}
+	
+	/**
+	*
+	* @param string $server addres of a remote server
+	* @param string $accessToken wopi access token from a remote server
+	* @return array|null with additional wopi information
+	*/
+	public function getWopiForToken($server, $remoteToken) {
+		$remote = $server;
+		// if (!$this->isTrustedServer($remote)) {
+		// 	$this->logger->info("Server {server} is not trusted.", ["server" => $remote]);
+		// 	return null;
+		// }
+
+		try {
+			$client = $this->httpClient->newClient();
+			$url = $remote . '/ocs/v2.php/apps/richdocuments/api/v1/federation';
+
+			$response = $client->post(
+				$url,
+				[
+				[
+					'form_params' => [
+						'token' => $remoteToken,
+						'format' => 'json'
+					],
+					'timeout' => 3,
+					'connect_timeout' => 3,
+				]
+			]
+			);
+
+			$responseBody = $response->getBody();
+			$data = \json_decode($responseBody, true, 512);
+
+			return $data['ocs']['data'];
+		} catch (\Throwable $e) {
+			$this->logger->info('Cannot get the wopi info from remote server: ' . $remote, ['exception' => $e]);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check if server is trusted
+	 *
+	 * @param string $remote a remote url
+	 * @return bool indicating if given remote is trusted server
+	 */
+	private function isTrustedServer($remote) {
+		$trustedServers = null;
+
+		try {
+			$trustedServers = \OC::$server->query(\OCA\Federation\TrustedServers::class);
+		} catch (QueryException $e) {
+			$this->logger->warning("Cannot load trusted servers.");
+		}
+
+		if ($trustedServers !== null && $trustedServers->isTrustedServer($remote)) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the wopiSrc Url from a remote server.
+	 *
+	 * @param string $remote a remote
+	 * @return string with the wopi src Url
+	 */
+	public function getRemoteWopiSrc($server, $token) {
+		if (\strpos($server, 'http://') === false && \strpos($server, 'https://') === false) {
+			$remote = 'https://' . $server;
+		}
+
+		// if (!$this->isTrustedServer($remote)) {
+		// 	$this->logger->info("Server {server} is not trusted.", ["server" => $remote]);
+		// 	return '';
+		// }
+
+		try {
+			$getWopiSrcUrl = $remote . '/ocs/v2.php/apps/richdocuments/api/v1/federation?format=json';
+			$client = \OC::$server->getHTTPClientService()->newClient();
+			$response = $client->get($getWopiSrcUrl, ['timeout' => 5]);
+			$data = \json_decode($response->getBody(), true);
+			$wopiSrc = $data['ocs']['data']['wopi_url'];
+			return $wopiSrc;
+		} catch (\Throwable $e) {
+			$this->logger->info('Cannot get the wopiSrc of remote server: ' . $remote, ['exception' => $e]);
+		}
+
+		return '';
+	}
+}

--- a/lib/FederationService.php
+++ b/lib/FederationService.php
@@ -120,18 +120,7 @@ class FederationService {
 	 * @return bool indicating if given remote is allowed server
 	 */
 	public function isServerAllowed($remote) {
-		// FIXME: implement check for trusted server, for a moment all trusted
-
-		// $trustedServers = null;
-		// try {
-		// 	$trustedServers = \OC::$server->query(\OCA\Federation\TrustedServers::class);
-		// } catch (QueryException $e) {
-		// 	$this->logger->warning("Cannot load trusted servers.");
-		// }
-		// if ($trustedServers !== null && $trustedServers->isTrustedServer($remote)) {
-		// 	return true;
-		// }
-		//return false;
+		// TODO: implement check for trusted server, for a moment all trusted
 
 		return true;
 	}

--- a/lib/FederationService.php
+++ b/lib/FederationService.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * @author Piotr Mrowczynski <piotr@owncloud.com>
+ * @author Szymon Kłos <szymon.klos@collabora.com>
  *
  * @copyright Copyright (c) 2023, ownCloud GmbH
  * @license AGPL-3.0
@@ -72,16 +73,16 @@ class FederationService {
 	 * Get the Url of the collabora document on a federated server.
 	 *
 	 * @param string $shareToken
-	 * @param string $path
+	 * @param string $shareRelativePath
 	 * @param string $server
 	 * @param string $accessToken
 	 * @return string with the Url to the given resource
 	 */
-	public function getRemoteFileUrl(string $shareToken, string $path, string $server, string $accessToken) : string {
+	public function getRemoteFileUrl(string $shareToken, string $shareRelativePath, string $server, string $accessToken) : string {
 		$serverHost = $this->urlGenerator->getAbsoluteURL('/');
 		$remoteFileUrl = \rtrim($server, '/') . '/index.php/apps/richdocuments/documents.php/federated' .
 			'?shareToken=' . $shareToken .
-			'&path=' . $path .
+			'&shareRelativePath=' . $shareRelativePath .
 			'&server=' . \rtrim($serverHost, '/') .
 			'&accessToken=' . $accessToken;
 		return $remoteFileUrl;
@@ -107,7 +108,6 @@ class FederationService {
 			$response = $client->post(
 				$url,
 				[
-				[
 					'form_params' => [
 						'token' => $remoteToken,
 						'format' => 'json'
@@ -115,7 +115,6 @@ class FederationService {
 					'timeout' => 3,
 					'connect_timeout' => 3,
 				]
-			]
 			);
 
 			$responseBody = $response->getBody();

--- a/lib/FileService.php
+++ b/lib/FileService.php
@@ -158,7 +158,7 @@ class FileService {
 				// emit login event to allow decryption of files via master key
 				$afterEvent = new GenericEvent(null, ['loginType' => 'password', 'user' => $user, 'uid' => $editorUID, 'password' => '']);
 				$this->eventDispatcher->dispatch($afterEvent, 'user.afterlogin');
-			} else {	
+			} else {
 				return null;
 			}
 		} else {

--- a/lib/FileService.php
+++ b/lib/FileService.php
@@ -133,6 +133,16 @@ class FileService {
 		return null;
 	}
 
+	/**
+	 * Create new file - uses privileged access to original file handle as user
+	 * for given fileId
+	 *
+	 * @param string $path original file path
+	 * @param string $ownerUID original file owner
+	 * @param string $editorUID file editor
+	 *
+	 * @return File|null
+	 */
 	public function newFile(string $path, string $ownerUID, string $editorUID): ?File {
 		if ($path === '') {
 			return null;

--- a/lib/FileService.php
+++ b/lib/FileService.php
@@ -82,25 +82,25 @@ class FileService {
 	 *
 	 * @param int $fileId original file id
 	 * @param string $ownerUID original file owner
-	 * @param string $userUID file editor
+	 * @param string $editorUID file editor (empty string if incognito mode)
 	 *
 	 * @return null|File
 	 */
-	public function getFileHandle(int $fileId, string $ownerUID, string $userUID): ?File {
+	public function getFileHandle(int $fileId, string $ownerUID, string $editorUID): ?File {
 		if (!$ownerUID) {
 			$this->logger->warning('getFileHandle(): owner must be provided', ['app' => 'richdocuments']);
 			return null;
 		}
 
-		if ($userUID) {
-			$user = $this->userManager->get($userUID);
+		if ($editorUID) {
+			$user = $this->userManager->get($editorUID);
 			if (!$user) {
 				$this->logger->warning('getFileHandle(): No such user', ['app' => 'richdocuments']);
 				return null;
 			}
 
 			// Make sure editor session is opened for registering activity over file handle
-			$this->logger->debug('getFileHandle(): Register session as ' . $userUID, ['app' => 'richdocuments']);
+			$this->logger->debug('getFileHandle(): Register session as ' . $editorUID, ['app' => 'richdocuments']);
 			if (!$this->appConfig->encryptionEnabled()) {
 				// Set session for a user
 				$this->userSession->setUser($user);
@@ -110,7 +110,7 @@ class FileService {
 				$this->userSession->setUser($user);
 
 				// emit login event to allow decryption of files via master key
-				$afterEvent = new GenericEvent(null, ['loginType' => 'password', 'user' => $user, 'uid' => $userUID, 'password' => '']);
+				$afterEvent = new GenericEvent(null, ['loginType' => 'password', 'user' => $user, 'uid' => $editorUID, 'password' => '']);
 				$this->eventDispatcher->dispatch($afterEvent, 'user.afterlogin');
 			} else {
 				// other type of encryption is enabled (e.g. user-key) that does not allow to decrypt files without incognito access to files

--- a/tests/unit/Controller/DocumentControllerTest.php
+++ b/tests/unit/Controller/DocumentControllerTest.php
@@ -11,7 +11,9 @@
 namespace OCA\Richdocuments\Tests\Controller;
 
 use OCA\Richdocuments\Controller\DocumentController;
+use OCA\Richdocuments\DocumentService;
 use OCA\Richdocuments\DiscoveryService;
+use OCA\Richdocuments\FederationService;
 use OCP\App\IAppManager;
 use OCP\IGroupManager;
 use OCP\INavigationManager;
@@ -22,7 +24,6 @@ use OCA\Richdocuments\AppConfig;
 use OCP\IL10N;
 use OCP\ICacheFactory;
 use OCP\ILogger;
-use OCA\Richdocuments\DocumentService;
 use OCP\IUserManager;
 
 /**
@@ -86,6 +87,10 @@ class DocumentControllerTest extends \Test\TestCase {
 	 */
 	private $navigationManager;
 	/**
+	 * @var FederationService
+	 */
+	private $federationService;
+	/**
 	 * @var DocumentController
 	 */
 	private $documentController;
@@ -105,6 +110,7 @@ class DocumentControllerTest extends \Test\TestCase {
 		$this->userManager = $this->createMock(IUserManager::class);
 		$this->previewManager = $this->createMock(IPreview::class);
 		$this->navigationManager = $this->createMock(INavigationManager::class);
+		$this->federationService = $this->createMock(FederationService::class);
 
 		$this->documentController = new DocumentController(
 			'richdocuments',
@@ -119,7 +125,8 @@ class DocumentControllerTest extends \Test\TestCase {
 			$this->groupManager,
 			$this->userManager,
 			$this->previewManager,
-			$this->navigationManager
+			$this->navigationManager,
+			$this->federationService
 		);
 	}
 

--- a/tests/unit/Controller/WopiControllerTest.php
+++ b/tests/unit/Controller/WopiControllerTest.php
@@ -31,6 +31,7 @@ use OCP\ILogger;
 use OCP\IUserManager;
 use OCP\IURLGenerator;
 use OCP\Files\IRootFolder;
+use OCP\Security\ISecureRandom;
 
 /**
  * Class WopiControllerTest
@@ -86,6 +87,11 @@ class WopiControllerTest extends \Test\TestCase {
 	private $userManager;
 
 	/**
+	 * @var ISecureRandom
+	 */
+	private $secureRandom;
+
+	/**
 	 * @var WopiController
 	 */
 	private $wopiController;
@@ -101,6 +107,7 @@ class WopiControllerTest extends \Test\TestCase {
 		$this->rootFolder = $this->createMock(IRootFolder::class);
 		$this->urlGenerator = $this->createMock(IURLGenerator::class);
 		$this->userManager = $this->createMock(IUserManager::class);
+		$this->secureRandom = $this->createMock(ISecureRandom::class);
 
 		$this->wopiController = new WopiController(
 			'richdocuments',
@@ -110,9 +117,9 @@ class WopiControllerTest extends \Test\TestCase {
 			$this->l10n,
 			$this->logger,
 			$this->fileService,
-			$this->rootFolder,
 			$this->urlGenerator,
-			$this->userManager
+			$this->userManager,
+			$this->secureRandom
 		);
 	}
 

--- a/tests/unit/DocumentServiceTest.php
+++ b/tests/unit/DocumentServiceTest.php
@@ -160,7 +160,8 @@ class DocumentServiceTest extends TestCase {
 			'secureView' => false,
 			'secureViewId' => null,
 			'federatedServer' => null,
-			'federatedToken' => null,
+			'federatedShareToken' => null,
+			'federatedShareRelativePath' => null,
 		];
 		$this->assertEquals($expected, $result);
 	}
@@ -272,7 +273,8 @@ class DocumentServiceTest extends TestCase {
 			'secureView' => true,
 			'secureViewId' => 567,
 			'federatedServer' => null,
-			'federatedToken' => null,
+			'federatedShareToken' => null,
+			'federatedShareRelativePath' => null,
 		];
 		$this->assertEquals($expected, $result);
 	}
@@ -335,12 +337,15 @@ class DocumentServiceTest extends TestCase {
 		$fileMount->expects($this->once())
 			->method('getPath')
 			->willReturn('/path/to/file.txt');
-		$rootFolder->expects($this->once())
-			->method('getRelativePath')
-			->with($this->equalTo('/path/to/file.txt'))
+		$fileMount->expects($this->once())
+			->method('getInternalPath')
 			->willReturn('file.txt');
 		$fileMount->expects($this->once())
 			->method('getName')
+			->willReturn('file.txt');
+		$rootFolder->expects($this->once())
+			->method('getRelativePath')
+			->with($this->equalTo('/path/to/file.txt'))
 			->willReturn('file.txt');
 
 		// Call the method being tested
@@ -360,7 +365,8 @@ class DocumentServiceTest extends TestCase {
 			'secureView' => false,
 			'secureViewId' => null,
 			'federatedServer' => 'fedinstance',
-			'federatedToken' => 'fedsharetoken',
+			'federatedShareToken' => 'fedsharetoken',
+			'federatedShareRelativePath' => 'file.txt',
 		];
 		$this->assertEquals($expected, $result);
 	}
@@ -449,7 +455,8 @@ class DocumentServiceTest extends TestCase {
 			'secureView' => false,
 			'secureViewId' => null,
 			'federatedServer' => null,
-			'federatedToken' => null,
+			'federatedShareToken' => null,
+			'federatedShareRelativePath' => null,
 		];
 		$this->assertEquals($expected, $result);
 	}

--- a/tests/unit/FederationServiceTest.php
+++ b/tests/unit/FederationServiceTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * @author Piotr Mrowczynski <piotr@owncloud.com>
+ *
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\Richdocuments\Tests;
+
+use OCA\Richdocuments\FederationService;
+use OCP\Http\Client\IClientService;
+use OCP\ILogger;
+use OCP\IURLGenerator;
+use PHPUnit\Framework\MockObject\MockObject;
+use Test\TestCase;
+
+class FederationServiceTest extends TestCase {
+	/**
+	 * The ILogger instance.
+	 *
+	 * @var ILogger
+	 */
+	private $logger;
+
+	/**
+	 * The IClientService instance.
+	 *
+	 * @var IClientService
+	 */
+	private $httpClient;
+
+	/**
+	 * The IURLGenerator instance.
+	 *
+	 * @var IURLGenerator
+	 */
+	private $urlGenerator;
+
+	/**
+	 * @var FederationService|MockObject The discovery service mock object.
+	 */
+	private $federationService;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->httpClient = $this->createMock(IClientService::class);
+
+		$this->federationService = new FederationService(
+			$this->logger,
+			$this->urlGenerator,
+			$this->httpClient
+		);
+	}
+
+	public function dataGenerateFederatedCloudID() {
+		$userPrefix = [
+			'username',
+			'1234'
+		];
+		$remotes = [
+			'localhost',
+			'local.host',
+			'dev.local.host',
+			'127.0.0.1',
+		];
+
+		$testCases = [];
+		foreach ($userPrefix as $user) {
+			foreach ($remotes as $remote) {
+				$testCases[] = [$user, $remote];
+			}
+		}
+		return $testCases;
+	}
+
+	/**
+	 * @dataProvider dataGenerateFederatedCloudID
+	 *
+	 * @param string $userId
+	 * @param string $expectedFederatedCloudID
+	 */
+	public function testSplitUserRemote($userId, $remote) {
+		$this->urlGenerator->method('getAbsoluteUrl')
+			->with('/')
+			->willReturn("https://{$remote}/");
+
+		$federatedCloudID = $this->federationService->generateFederatedCloudID($userId);
+
+		$this->assertSame("{$userId}@{$remote}", $federatedCloudID);
+	}
+}


### PR DESCRIPTION
implements https://github.com/owncloud/richdocuments/issues/381

- [x] on detected federated document redirect to remote server 
- [x] add basic "federated handshake" handling assigning "remote user" as editor uid
- [x] make sure to assign proper serverHost in the wopi token db entry on both servers (we need to keep track on both servers that the editing is happening and where the user got redirected)
- [x] make sure to assign proper access_token in the wopi token db entry on both servers (in case remotes need to exchange some further information between each other)
- [x] extend "federated handshake" to allow to retrieve editor uid and other wopi session details from remote
- [x] adjust tests
- [x] make sure to use new major version for the release @jnweiger 