### PR TITLE
fix: drop usage of ${}

### DIFF
--- a/appinfo/Migrations/Version20190310162809.php
+++ b/appinfo/Migrations/Version20190310162809.php
@@ -38,7 +38,7 @@ class Version20190310162809 implements ISchemaMigration {
 
 		// create richdocuments wopi tokens table, which will be used for
 		// wopi session tokens for the users
-		$table = $schema->createTable("${prefix}richdocuments_wopi");
+		$table = $schema->createTable("{$prefix}richdocuments_wopi");
 
 		// Document owner UserId - a textual user identifier
 		$table->addColumn('owner_uid', 'text', [


### PR DESCRIPTION
## Description
In preparation of php8.2 support - see https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

Similar to core https://github.com/owncloud/core/pull/40995
