### PR TITLE
Update route to documents.php/index

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -49,7 +49,7 @@ class Application extends App {
 					return [
 						'id' => 'richdocuments_index',
 						'order' => 2,
-						'href' => $container->query('ServerContainer')->getURLGenerator()->linkToRoute('richdocuments.document.index'),
+						'href' => $container->query('ServerContainer')->getURLGenerator()->linkToRoute('richdocuments.Document.index'),
 						'icon' => $container->query('ServerContainer')->getURLGenerator()->imagePath('richdocuments', 'app.svg'),
 						'name' => $container->query('L10N')->t('Office')
 					];


### PR DESCRIPTION
https://github.com/owncloud/richdocuments/pull/522/files#diff-6301937af1cc1575e9e18ecd27c4a51f0d3cf9ce12e59a14709f626dfa3ef952R28 (first added in richdocuments 4.1.0) introduced a change to the documents.php/index route but https://github.com/owncloud/richdocuments/blob/master/lib/AppInfo/Application.php#L52 was not updated.

As as result, currently on 4.1.0 the `Files->Office` menu is not reachable (icon is there but you get redirected back to the files page).

Related issue: https://github.com/owncloud/enterprise/issues/6349