### PR TITLE
Fix Documents unable to open after release 4

### DIFF
--- a/lib/DocumentService.php
+++ b/lib/DocumentService.php
@@ -140,17 +140,20 @@ class DocumentService {
 		try {
 			// if dir is set, then we need to check fileId in that folder,
 			// as in case of user/group shares we can have multiple file mounts with same id
-			// return these fileMounts
-			if ($dir !== null) {
-				/** @var \OCP\Files\Folder $parentFolder */
-				$parentFolder = $root->get($dir);
+			// return these fileMounts based on fileId
+			$fileMounts = $root->getById($fileId);
 
-				/** @phpstan-ignore-next-line */
-				'@phan-var \OCP\Files\Folder $parentFolder';
-				$fileMounts = $parentFolder->getById($fileId);
-			} else {
-				$fileMounts = $root->getById($fileId);
-			}
+//			// return these fileMounts
+//			if ($dir !== null) {
+//				/** @var \OCP\Files\Folder $parentFolder */
+//				$parentFolder = $root->get($dir);
+//
+//				/** @phpstan-ignore-next-line */
+//				'@phan-var \OCP\Files\Folder $parentFolder';
+//				$fileMounts = $parentFolder->getById($fileId);
+//			} else {
+//				$fileMounts = $root->getById($fileId);
+//			}
 			
 			$document = $fileMounts[0] ?? null;
 			if ($document === null) {


### PR DESCRIPTION
See comment on this issue; https://github.com/owncloud/richdocuments/issues/533#issuecomment-2042867565

When a user copies the URL from the browser and gives it to another user who has a share on the document, the document may not be able to be opened.

This may be the case when the document is in a different directory at the receiving end than the sending end. Now the path is taken which is in the URL. By looking only at the fileid instead of the directory in the URL, the document can be opened.