### PR TITLE
chore: use reusable build workflow for make dist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,9 +60,4 @@ jobs:
     needs:
       - php-code-style
       - php-unit
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Build
-        run: make dist
+    uses: owncloud/reusable-workflows/.github/workflows/build.yml@main


### PR DESCRIPTION
Adopts the reusable `build` workflow from [owncloud/reusable-workflows](https://github.com/owncloud/reusable-workflows) to run `make dist` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)